### PR TITLE
Add on pull_request so Test Workflow Runs with Pull Requests

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -1,5 +1,5 @@
 name: test-gh
-on: [push]
+on: [push, pull_request]
 jobs:
   test-all:
     name: Test GH


### PR DESCRIPTION
Noticed from a recently opened pull request that tests are not running as part of the pull request process, so this pull request adds `pull_request` to the `on` property to run tests for new prs. 