### PR TITLE
Update Hardcoded Repo Name in Workflow

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
       with:
-        path: src/github.com/k14s/vendir
+        path: src/github.com/${{ github.repository }}
     - name: Run Tests
       run: |
         set -e -x

--- a/examples/github-release/vendir.lock.yml
+++ b/examples/github-release/vendir.lock.yml
@@ -3,7 +3,7 @@ directories:
 - contents:
   - githubRelease:
       url: https://api.github.com/repos/vmware-tanzu/carvel-kapp-controller/releases/21912613
-    path: github.com/vmware-tanzu/carvel-kapp-controller
+    path: github.com/k14s/kapp-controller
   - githubRelease:
       url: https://api.github.com/repos/pivotal/kpack/releases/22747441
     path: github.com/pivotal/kpack

--- a/examples/github-release/vendir.lock.yml
+++ b/examples/github-release/vendir.lock.yml
@@ -2,8 +2,8 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - githubRelease:
-      url: https://api.github.com/repos/k14s/kapp-controller/releases/21912613
-    path: github.com/k14s/kapp-controller
+      url: https://api.github.com/repos/vmware-tanzu/carvel-kapp-controller/releases/21912613
+    path: github.com/vmware-tanzu/carvel-kapp-controller
   - githubRelease:
       url: https://api.github.com/repos/pivotal/kpack/releases/22747441
     path: github.com/pivotal/kpack

--- a/examples/github-release/vendir.yml
+++ b/examples/github-release/vendir.yml
@@ -5,9 +5,9 @@ directories:
   contents:
 
   # validates checksums automatically from release notes
-  - path: github.com/vmware-tanzu/carvel-kapp-controller
+  - path: github.com/k14s/kapp-controller
     githubRelease:
-      slug: vmware-tanzu/carvel-kapp-controller
+      slug: k14s/kapp-controller
       tag: v0.1.0
 
   # skips checkum validation

--- a/examples/github-release/vendir.yml
+++ b/examples/github-release/vendir.yml
@@ -5,9 +5,9 @@ directories:
   contents:
 
   # validates checksums automatically from release notes
-  - path: github.com/k14s/kapp-controller
+  - path: github.com/vmware-tanzu/carvel-kapp-controller
     githubRelease:
-      slug: k14s/kapp-controller
+      slug: vmware-tanzu/carvel-kapp-controller
       tag: v0.1.0
 
   # skips checkum validation

--- a/examples/locked/vendir.lock.yml
+++ b/examples/locked/vendir.lock.yml
@@ -7,7 +7,7 @@ directories:
     path: github.com/cloudfoundry/cf-k8s-networking
   - githubRelease:
       url: https://api.github.com/repos/vmware-tanzu/carvel-kapp-controller/releases/21912613
-    path: github.com/vmware-tanzu/carvel-kapp-controller
+    path: github.com/k14s/kapp-controller
   - helmChart:
       appVersion: 1.8.0
       version: 1.2.1

--- a/examples/locked/vendir.lock.yml
+++ b/examples/locked/vendir.lock.yml
@@ -6,8 +6,8 @@ directories:
       sha: e4f715485ff4484ce571cd31dcba5b6e47475f22
     path: github.com/cloudfoundry/cf-k8s-networking
   - githubRelease:
-      url: https://api.github.com/repos/k14s/kapp-controller/releases/21912613
-    path: github.com/k14s/kapp-controller
+      url: https://api.github.com/repos/vmware-tanzu/carvel-kapp-controller/releases/21912613
+    path: github.com/vmware-tanzu/carvel-kapp-controller
   - helmChart:
       appVersion: 1.8.0
       version: 1.2.1


### PR DESCRIPTION
Updating checkout step to use `${{ github.repository }}` for its path to help with transitioning to new org. Should be aliased, but might be nice to avoid confusion if someone is reviewing CI process.

Also changing GitHub release url to reflect changed repo location of kapp-controller.