### PR TITLE
vendir config example for refSelection minimum version 0.11.0

### DIFF
--- a/examples/versionselection/vendir.yml
+++ b/examples/versionselection/vendir.yml
@@ -1,6 +1,6 @@
 apiVersion: vendir.k14s.io/v1alpha1
 kind: Config
-minimumRequiredVersion: 0.8.0
+minimumRequiredVersion: 0.11.0
 directories:
 - path: vendor
   contents:


### PR DESCRIPTION
refSelection appears to have been introduced in 0.11.0 (https://github.com/vmware-tanzu/carvel-vendir/releases/tag/v0.11.0); this updates the minimumConfig version in these examples to reference 0.11.0 rather than 0.8.0