### PR TITLE
Label automation

### DIFF
--- a/.github/workflows/closed-issue-label.yml
+++ b/.github/workflows/closed-issue-label.yml
@@ -1,0 +1,17 @@
+name: Closed issue labeling
+on:
+  issues:
+    types: ['reopened']
+  issue_comment:
+    types: ['created']
+
+jobs:
+  add-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://k8slt/closed-issue-label-action@sha256:84360552559e0de4dfaaeefcf1ea0a1070a6250621f98539caf3eaad9395feb7
+        if: github.event_name == 'issues' || ( github.event_name == 'issue_comment' && github.event.issue.state == 'closed')
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ignore-comments: true
+          default-labels: '["carvel-triage"]'

--- a/.github/workflows/stale-issues-action.yml
+++ b/.github/workflows/stale-issues-action.yml
@@ -1,0 +1,21 @@
+name: Mark issues stale and close stale issues
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@87c2b794b9b47a9bec68ae03c01aeb572ffebdb1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is being marked as stale due to a long period of inactivity and will be closed in 5 days if there is no response.'
+        stale-issue-label: 'stale'
+        exempt-issue-label: 'discussion'
+        only-labels: 'carvel-triage'
+        days-before-stale: 40
+        days-before-close: 5


### PR DESCRIPTION
Automatically adds the label carvel-triage to issues that are reopened and to issues that are closed but a new comment is added.
Automatically marks the issue with a stale label 40 days of inactivity and will close that issue after 5 more days