### PR TITLE
Adding golint and goheader linters via golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,18 @@
+name: golangci-lint
+
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.34
+          args: -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+linters:
+  enable:
+    - goheader
+    - golint
+  disable-all: true
+# all available settings of specific linters
+linters-settings:
+  goheader:
+    template-path: code-header-template.txt
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/cmd/vendir/vendir.go
+++ b/cmd/vendir/vendir.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/code-header-template.txt
+++ b/code-header-template.txt
@@ -1,0 +1,2 @@
+Copyright 2020 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0

--- a/hack/build-and-lint.sh
+++ b/hack/build-and-lint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e -x -u
+
+./hack/build.sh
+./hack/linter.sh

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+golangci-lint cache clean
+golangci-lint run

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,7 +1,7 @@
- // Copyright 2020 VMware, Inc.
- // SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+// +build tools
 
 package tools
 
 import _ "k8s.io/code-generator"
-

--- a/pkg/vendir/cmd/sync.go
+++ b/pkg/vendir/cmd/sync.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/pkg/vendir/cmd/tools.go
+++ b/pkg/vendir/cmd/tools.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/pkg/vendir/cmd/ui_flags.go
+++ b/pkg/vendir/cmd/ui_flags.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/pkg/vendir/cmd/vendir.go
+++ b/pkg/vendir/cmd/vendir.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/pkg/vendir/cmd/version.go
+++ b/pkg/vendir/cmd/version.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/pkg/vendir/config/config.go
+++ b/pkg/vendir/config/config.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/vendir/config/data.go
+++ b/pkg/vendir/config/data.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 const (
@@ -24,6 +27,7 @@ type Secret struct {
 	Data     map[string][]byte
 }
 
+// nolint:golint
 type ConfigMap struct {
 	APIVersion string
 	Kind       string

--- a/pkg/vendir/config/directory.go
+++ b/pkg/vendir/config/directory.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/vendir/config/lock_config.go
+++ b/pkg/vendir/config/lock_config.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/vendir/config/lock_directory.go
+++ b/pkg/vendir/config/lock_directory.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 type LockDirectory struct {

--- a/pkg/vendir/config/resources.go
+++ b/pkg/vendir/config/resources.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/vendir/directory/directory.go
+++ b/pkg/vendir/directory/directory.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package directory
 
 import (

--- a/pkg/vendir/directory/file_filter.go
+++ b/pkg/vendir/directory/file_filter.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package directory
 
 import (

--- a/pkg/vendir/directory/info_log.go
+++ b/pkg/vendir/directory/info_log.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package directory
 
 import (

--- a/pkg/vendir/directory/named_ref_fetcher.go
+++ b/pkg/vendir/directory/named_ref_fetcher.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package directory
 
 import (

--- a/pkg/vendir/directory/staging_dir.go
+++ b/pkg/vendir/directory/staging_dir.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package directory
 
 import (

--- a/pkg/vendir/fetch/archive.go
+++ b/pkg/vendir/fetch/archive.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package fetch
 
 import (

--- a/pkg/vendir/fetch/git/git.go
+++ b/pkg/vendir/fetch/git/git.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package git
 
 import (
@@ -28,6 +31,7 @@ func NewGit(opts ctlconf.DirectoryContentsGit,
 	return &Git{opts, infoLog, refFetcher}
 }
 
+// nolint:golint
 type GitInfo struct {
 	SHA         string
 	Tags        []string
@@ -117,23 +121,23 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea) error {
 		env = append(env, "GIT_LFS_SKIP_SMUDGE=1")
 	}
 
-	gitUrl := t.opts.URL
+	gitURL := t.opts.URL
 	gitCredsPath := filepath.Join(authDir, ".git-credentials")
 
 	if authOpts.Username != nil && authOpts.Password != nil {
-		if !strings.HasPrefix(gitUrl, "https://") {
+		if !strings.HasPrefix(gitURL, "https://") {
 			return fmt.Errorf("Username/password authentication is only supported for https remotes")
 		}
 
-		gitCredsUrl, err := url.Parse(gitUrl)
+		gitCredsURL, err := url.Parse(gitURL)
 		if err != nil {
 			return fmt.Errorf("Parsing git remote url: %s", err)
 		}
 
-		gitCredsUrl.User = url.UserPassword(*authOpts.Username, *authOpts.Password)
-		gitCredsUrl.Path = ""
+		gitCredsURL.User = url.UserPassword(*authOpts.Username, *authOpts.Password)
+		gitCredsURL.Path = ""
 
-		err = ioutil.WriteFile(gitCredsPath, []byte(gitCredsUrl.String()+"\n"), 0600)
+		err = ioutil.WriteFile(gitCredsPath, []byte(gitCredsURL.String()+"\n"), 0600)
 		if err != nil {
 			return fmt.Errorf("Writing %s: %s", gitCredsPath, err)
 		}
@@ -142,7 +146,7 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea) error {
 	argss := [][]string{
 		{"init"},
 		{"config", "credential.helper", "store --file " + gitCredsPath},
-		{"remote", "add", "origin", gitUrl},
+		{"remote", "add", "origin", gitURL},
 		{"fetch", "origin"},
 	}
 

--- a/pkg/vendir/fetch/git/line_section_reader.go
+++ b/pkg/vendir/fetch/git/line_section_reader.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package git
 
 import (

--- a/pkg/vendir/fetch/git/sync.go
+++ b/pkg/vendir/fetch/git/sync.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package git
 
 import (

--- a/pkg/vendir/fetch/git/verification.go
+++ b/pkg/vendir/fetch/git/verification.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package git
 
 import (

--- a/pkg/vendir/fetch/githubrelease/release_notes_checksums.go
+++ b/pkg/vendir/fetch/githubrelease/release_notes_checksums.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package githubrelease
 
 import (
@@ -8,7 +11,7 @@ import (
 
 type ReleaseNotesChecksums struct{}
 
-func (ReleaseNotesChecksums) Find(assets []GithubReleaseAssetAPI, body string) (map[string]string, error) {
+func (ReleaseNotesChecksums) Find(assets []ReleaseAssetAPI, body string) (map[string]string, error) {
 	lines := strings.Split(body, "\n")
 	results := map[string]string{}
 

--- a/pkg/vendir/fetch/githubrelease/release_notes_checksums_test.go
+++ b/pkg/vendir/fetch/githubrelease/release_notes_checksums_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package githubrelease_test
 
 import (
@@ -20,7 +23,7 @@ func TestReleaseNotesChecksums(t *testing.T) {
 +++
 `
 
-	files := []GithubReleaseAssetAPI{
+	files := []ReleaseAssetAPI{
 		{Name: "release.yml"},
 		{Name: "with-slash.yml"},
 		{Name: "with-period-slash.yml"},

--- a/pkg/vendir/fetch/githubrelease/sync.go
+++ b/pkg/vendir/fetch/githubrelease/sync.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package githubrelease
 
 import (
@@ -17,14 +20,14 @@ import (
 
 type Sync struct {
 	opts            ctlconf.DirectoryContentsGithubRelease
-	defaultApiToken string
+	defaultAPIToken string
 	refFetcher      ctlfetch.RefFetcher
 }
 
 func NewSync(opts ctlconf.DirectoryContentsGithubRelease,
-	defaultApiToken string, refFetcher ctlfetch.RefFetcher) Sync {
+	defaultAPIToken string, refFetcher ctlfetch.RefFetcher) Sync {
 
-	return Sync{opts, defaultApiToken, refFetcher}
+	return Sync{opts, defaultAPIToken, refFetcher}
 }
 
 func (d Sync) DescAndURL() (string, string, error) {
@@ -68,7 +71,7 @@ func (d Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDire
 	}
 
 	fileChecksums := map[string]string{}
-	matchedAssets := []GithubReleaseAssetAPI{}
+	matchedAssets := []ReleaseAssetAPI{}
 
 	for _, asset := range releaseAPI.Assets {
 		matched, err := d.matchesAssetName(asset.Name)
@@ -162,8 +165,8 @@ func (d Sync) matchesAssetName(name string) (bool, error) {
 	return false, nil
 }
 
-func (d Sync) downloadRelease(authToken string) (GithubReleaseAPI, error) {
-	releaseAPI := GithubReleaseAPI{}
+func (d Sync) downloadRelease(authToken string) (ReleaseAPI, error) {
+	releaseAPI := ReleaseAPI{}
 
 	_, url, err := d.DescAndURL()
 	if err != nil {
@@ -291,8 +294,8 @@ func (d Sync) checkFileChecksum(path string, expectedChecksum string) error {
 func (d Sync) authToken() (string, error) {
 	token := ""
 
-	if len(d.defaultApiToken) > 0 {
-		token = d.defaultApiToken
+	if len(d.defaultAPIToken) > 0 {
+		token = d.defaultAPIToken
 	}
 
 	if d.opts.SecretRef != nil {
@@ -314,13 +317,13 @@ func (d Sync) authToken() (string, error) {
 	return token, nil
 }
 
-type GithubReleaseAPI struct {
+type ReleaseAPI struct {
 	URL    string `json:"url"`
 	Body   string
-	Assets []GithubReleaseAssetAPI
+	Assets []ReleaseAssetAPI
 }
 
-type GithubReleaseAssetAPI struct {
+type ReleaseAssetAPI struct {
 	URL  string
 	Name string
 	Size int64
@@ -328,7 +331,7 @@ type GithubReleaseAssetAPI struct {
 	// BrowserDownloadURL string `json:"browser_download_url"`
 }
 
-func (a GithubReleaseAPI) AssetNames() []string {
+func (a ReleaseAPI) AssetNames() []string {
 	var result []string
 	for _, asset := range a.Assets {
 		result = append(result, asset.Name)

--- a/pkg/vendir/fetch/http/sync.go
+++ b/pkg/vendir/fetch/http/sync.go
@@ -132,7 +132,7 @@ func (t *Sync) addAuth(req *http.Request) error {
 		return err
 	}
 
-	for name, _ := range secret.Data {
+	for name := range secret.Data {
 		switch name {
 		case ctlconf.SecretK8sCorev1BasicAuthUsernameKey:
 		case ctlconf.SecretK8sCorev1BasicAuthPasswordKey:

--- a/pkg/vendir/fetch/move.go
+++ b/pkg/vendir/fetch/move.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package fetch
 
 import (

--- a/pkg/vendir/fetch/ref_fetcher.go
+++ b/pkg/vendir/fetch/ref_fetcher.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package fetch
 
 import (

--- a/pkg/vendir/fetch/temp_area.go
+++ b/pkg/vendir/fetch/temp_area.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package fetch
 
 import (

--- a/pkg/vendir/openpgparmor/armor.go
+++ b/pkg/vendir/openpgparmor/armor.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package openpgparmor
 
 import (

--- a/pkg/vendir/version/version.go
+++ b/pkg/vendir/version/version.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package version
 
 const (

--- a/pkg/vendir/versions/v1alpha1/config.go
+++ b/pkg/vendir/versions/v1alpha1/config.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 // +k8s:deepcopy-gen=true

--- a/pkg/vendir/versions/v1alpha1/selector.go
+++ b/pkg/vendir/versions/v1alpha1/selector.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import "fmt"

--- a/pkg/vendir/versions/v1alpha1/semvers.go
+++ b/pkg/vendir/versions/v1alpha1/semvers.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/pkg/vendir/versions/v1alpha1/semvers_test.go
+++ b/pkg/vendir/versions/v1alpha1/semvers_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1_test
 
 import (

--- a/test/e2e/directory_flag_test.go
+++ b/test/e2e/directory_flag_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/env.go
+++ b/test/e2e/env.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/example.go
+++ b/test/e2e/example.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/example_git_and_manual_test.go
+++ b/test/e2e/example_git_and_manual_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/example_locked_test.go
+++ b/test/e2e/example_locked_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/examples_dir_test.go
+++ b/test/e2e/examples_dir_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/git_test.go
+++ b/test/e2e/git_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/min_version_err_test.go
+++ b/test/e2e/min_version_err_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/misc_test.go
+++ b/test/e2e/misc_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/overlapping_dir_err_test.go
+++ b/test/e2e/overlapping_dir_err_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/secrets_test.go
+++ b/test/e2e/secrets_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/vendir.go
+++ b/test/e2e/vendir.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (


### PR DESCRIPTION
Adding go-lint/goheader linters to CI. Also fixing violations flagged by go-lint/goheader. To review those changes, see commit [`fa083bd`](https://github.com/vmware-tanzu/carvel-vendir/commit/fa083bd97b5ae9bcb67b3c25542f35186241540c).