### PR TITLE
Helm OCI chart fetch

### DIFF
--- a/examples/git/vendir.yml
+++ b/examples/git/vendir.yml
@@ -13,7 +13,7 @@ directories:
 
   - path: tag
     git:
-      url: https://github.com/cloudfoundry/cf-k8s-networking
+      url: https://github.com/cloudfoundry/cf-for-k8s
       ref: v0.4.0
     includePaths:
     - config/**/*

--- a/examples/versionselection/vendir.yml
+++ b/examples/versionselection/vendir.yml
@@ -6,7 +6,7 @@ directories:
   contents:
   - path: github.com/cloudfoundry/cf-k8s-networking
     git:
-      url: https://github.com/cloudfoundry/cf-k8s-networking
+      url: https://github.com/cloudfoundry/cf-for-k8s
       refSelection:
         semver:
           constraints: ">0.2.0 <0.4.0"

--- a/pkg/vendir/config/data.go
+++ b/pkg/vendir/config/data.go
@@ -24,6 +24,7 @@ type Secret struct {
 	Kind       string
 
 	Metadata GenericMetadata
+	Type     string
 	Data     map[string][]byte
 }
 

--- a/pkg/vendir/config/dockerconfigjson.go
+++ b/pkg/vendir/config/dockerconfigjson.go
@@ -1,0 +1,52 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type secretDockerConfigJSON struct {
+	Auths map[string]secretDockerConfigJSONAuth
+}
+
+type secretDockerConfigJSONAuth struct {
+	Username string
+	Password string
+}
+
+func (s Secret) ToBasicAuthSecret() (Secret, error) {
+	const (
+		// Constants from Kubernetes core v1
+		typeDockerConfigJSON = "kubernetes.io/dockerconfigjson"
+		dockerConfigJSONKey  = ".dockerconfigjson"
+	)
+
+	if s.Type != typeDockerConfigJSON {
+		return s, nil // return itself
+	}
+
+	var data secretDockerConfigJSON
+
+	err := json.Unmarshal(s.Data[dockerConfigJSONKey], &data)
+	if err != nil {
+		return Secret{}, err
+	}
+
+	if len(data.Auths) != 1 {
+		return Secret{}, fmt.Errorf("Expected exactly one registry configuration within a secret")
+	}
+
+	for _, auth := range data.Auths {
+		return Secret{
+			Data: map[string][]byte{
+				SecretK8sCorev1BasicAuthUsernameKey: []byte(auth.Username),
+				SecretK8sCorev1BasicAuthPasswordKey: []byte(auth.Password),
+			},
+		}, nil
+	}
+
+	panic("Unreachable")
+}

--- a/pkg/vendir/config/dockerconfigjson_test.go
+++ b/pkg/vendir/config/dockerconfigjson_test.go
@@ -1,0 +1,68 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	. "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/config"
+)
+
+func TestSecretToBasicAuthSecretNoop(t *testing.T) {
+	s1 := Secret{Data: map[string][]byte{"test": []byte("abc")}}
+
+	result, err := s1.ToBasicAuthSecret()
+	if err != nil {
+		t.Fatalf("Expected nil err, but was: %s", err)
+	}
+
+	if !reflect.DeepEqual(s1, result) {
+		t.Fatalf("Expected same secret to be returned")
+	}
+}
+
+func TestSecretToBasicAuthSecretWithDockerConfigJson(t *testing.T) {
+	s1 := Secret{
+		Type: "kubernetes.io/dockerconfigjson",
+		Data: map[string][]byte{
+			".dockerconfigjson": []byte(`{"auths":{"registry.io":{"username":"user","password":"pass"}}}`),
+		},
+	}
+
+	expectedS := Secret{
+		Data: map[string][]byte{
+			"username": []byte("user"),
+			"password": []byte("pass"),
+		},
+	}
+
+	result, err := s1.ToBasicAuthSecret()
+	if err != nil {
+		t.Fatalf("Expected nil err, but was: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, expectedS) {
+		t.Fatalf("Expected secret to be turned into username/password secret")
+	}
+}
+
+func TestSecretToBasicAuthSecretWithDockerConfigJsonTooManyRegistries(t *testing.T) {
+	s1 := Secret{
+		Type: "kubernetes.io/dockerconfigjson",
+		Data: map[string][]byte{
+			".dockerconfigjson": []byte(`{"auths":{"registry.io":{"username":"user","password":"pass"}, "foo":{}}}`),
+		},
+	}
+
+	_, err := s1.ToBasicAuthSecret()
+	if err == nil {
+		t.Fatalf("Expected non-nil err")
+	}
+
+	if !strings.Contains(err.Error(), "Expected exactly one registry configuration within a secret") {
+		t.Fatalf("Expected one registry configuration error, but found err: %s", err)
+	}
+}

--- a/pkg/vendir/fetch/helmchart/http_source.go
+++ b/pkg/vendir/fetch/helmchart/http_source.go
@@ -1,0 +1,166 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package helmchart
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	ctlconf "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/config"
+	ctlfetch "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/fetch"
+)
+
+type HTTPSource struct {
+	opts       ctlconf.DirectoryContentsHelmChart
+	helmBinary string
+	refFetcher ctlfetch.RefFetcher
+}
+
+func NewHTTPSource(opts ctlconf.DirectoryContentsHelmChart,
+	helmBinary string, refFetcher ctlfetch.RefFetcher) *HTTPSource {
+
+	return &HTTPSource{opts, helmBinary, refFetcher}
+}
+
+func (t *HTTPSource) Fetch(dstPath string, tempArea ctlfetch.TempArea) error {
+	helmHomeDir, err := tempArea.NewTempDir("helm-home")
+	if err != nil {
+		return err
+	}
+
+	defer os.RemoveAll(helmHomeDir)
+
+	err = t.init(helmHomeDir)
+	if err != nil {
+		return err
+	}
+
+	return t.fetch(helmHomeDir, dstPath)
+}
+
+func (t *HTTPSource) init(helmHomeDir string) error {
+	args := []string{"init", "--client-only"}
+
+	var stdoutBs, stderrBs bytes.Buffer
+
+	cmd := exec.Command(t.helmBinary, args...)
+	cmd.Env = []string{"HOME=" + helmHomeDir}
+	cmd.Stdout = &stdoutBs
+	cmd.Stderr = &stderrBs
+
+	err := cmd.Run()
+	if err != nil {
+		stderrStr := stderrBs.String()
+		// Helm 3 does not have/need init command
+		if strings.Contains(stderrStr, "unknown command") {
+			return nil
+		}
+
+		return fmt.Errorf("Init helm: %s (stderr: %s)", err, stderrStr)
+	}
+
+	return nil
+}
+
+func (t *HTTPSource) fetch(helmHomeDir, chartsPath string) error {
+	const (
+		stablePrefix  = "stable/"
+		stableRepoURL = "https://kubernetes-charts.storage.googleapis.com"
+	)
+
+	var name, repoURL string
+
+	if strings.HasPrefix(t.opts.Name, stablePrefix) {
+		name = strings.TrimPrefix(t.opts.Name, stablePrefix)
+		repoURL = stableRepoURL
+	} else {
+		name = t.opts.Name
+	}
+
+	fetchArgs := []string{"fetch", name, "--untar", "--untardir", chartsPath}
+
+	if len(t.opts.Version) > 0 {
+		fetchArgs = append(fetchArgs, []string{"--version", t.opts.Version}...)
+	}
+
+	if t.opts.Repository != nil {
+		if len(t.opts.Repository.URL) == 0 {
+			return fmt.Errorf("Expected non-empty repository URL")
+		}
+		repoURL = t.opts.Repository.URL
+	}
+
+	if len(repoURL) > 0 {
+		// Add repo explicitly for helm to be recognized in fetch command
+		{
+			repoAddArgs := []string{"repo", "add", "vendir-unused", repoURL}
+			repoAddArgs, err := t.addAuthArgs(repoAddArgs)
+			if err != nil {
+				return fmt.Errorf("Adding helm chart auth info: %s", err)
+			}
+
+			var stdoutBs, stderrBs bytes.Buffer
+
+			cmd := exec.Command(t.helmBinary, repoAddArgs...)
+			cmd.Env = []string{"HOME=" + helmHomeDir}
+			cmd.Stdout = &stdoutBs
+			cmd.Stderr = &stderrBs
+
+			err = cmd.Run()
+			if err != nil {
+				return fmt.Errorf("Add helm chart repository: %s (stderr: %s)", err, stderrBs.String())
+			}
+		}
+
+		fetchArgs = append(fetchArgs, []string{"--repo", repoURL}...)
+
+		var err error
+
+		fetchArgs, err = t.addAuthArgs(fetchArgs)
+		if err != nil {
+			return fmt.Errorf("Adding helm chart auth info: %s", err)
+		}
+	}
+
+	var stdoutBs, stderrBs bytes.Buffer
+
+	cmd := exec.Command(t.helmBinary, fetchArgs...)
+	cmd.Env = []string{"HOME=" + helmHomeDir}
+	cmd.Stdout = &stdoutBs
+	cmd.Stderr = &stderrBs
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Fetching helm chart: %s (stderr: %s)", err, stderrBs.String())
+	}
+
+	return nil
+}
+
+func (t *HTTPSource) addAuthArgs(args []string) ([]string, error) {
+	var authArgs []string
+
+	if t.opts.Repository != nil && t.opts.Repository.SecretRef != nil {
+		secret, err := t.refFetcher.GetSecret(t.opts.Repository.SecretRef.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for name, val := range secret.Data {
+			switch name {
+			case ctlconf.SecretK8sCorev1BasicAuthUsernameKey:
+				authArgs = append(authArgs, []string{"--username", string(val)}...)
+			case ctlconf.SecretK8sCorev1BasicAuthPasswordKey:
+				authArgs = append(authArgs, []string{"--password", string(val)}...)
+			default:
+				return nil, fmt.Errorf("Unknown secret field '%s' in secret '%s'", name, secret.Metadata.Name)
+			}
+		}
+	}
+
+	return append(args, authArgs...), nil
+}

--- a/pkg/vendir/fetch/helmchart/oci_source.go
+++ b/pkg/vendir/fetch/helmchart/oci_source.go
@@ -176,6 +176,11 @@ func (t *OCISource) addAuthArgs(args []string) ([]string, io.Reader, error) {
 			return nil, nil, err
 		}
 
+		secret, err = secret.ToBasicAuthSecret()
+		if err != nil {
+			return nil, nil, err
+		}
+
 		for name, val := range secret.Data {
 			switch name {
 			case ctlconf.SecretK8sCorev1BasicAuthUsernameKey:

--- a/pkg/vendir/fetch/helmchart/oci_source.go
+++ b/pkg/vendir/fetch/helmchart/oci_source.go
@@ -1,0 +1,193 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package helmchart
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	ctlconf "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/config"
+	ctlfetch "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/fetch"
+)
+
+/*
+
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+- path: config
+  contents:
+  - path: .
+    helmChart:
+      name: grafana
+      version: 5.2.10
+      repository:
+        url: oci://registry.corp.com/projects/charts
+
+...will result in...
+
+$ export HELM_EXPERIMENTAL_OCI=1
+$ helm registry login registry.corp.com/projects/charts
+$ helm chart pull     registry.corp.com/projects/charts/grafana:5.2.10
+$ helm chart export   registry.corp.com/projects/charts/grafana:5.2.10
+
+Handy command to run registry with certs:
+
+$ docker run -d -p 5000:5000 --name registry -v /Users/dk/workspace/cert:/certs \
+	-e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
+	-e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
+	-e REGISTRY_HTTP_TLS_KEY=/certs/domain.key registry:2
+$ docker stop registry && docker rm registry
+
+*/
+
+type OCISource struct {
+	opts       ctlconf.DirectoryContentsHelmChart
+	helmBinary string
+	refFetcher ctlfetch.RefFetcher
+}
+
+func NewOCISource(opts ctlconf.DirectoryContentsHelmChart,
+	helmBinary string, refFetcher ctlfetch.RefFetcher) *OCISource {
+
+	return &OCISource{opts, helmBinary, refFetcher}
+}
+
+func (t *OCISource) Fetch(dstPath string, tempArea ctlfetch.TempArea) error {
+	if len(t.opts.Name) == 0 {
+		return fmt.Errorf("Expected non-empty name")
+	}
+	if len(t.opts.Version) == 0 {
+		return fmt.Errorf("Expected non-empty version")
+	}
+	if t.opts.Repository == nil || len(t.opts.Repository.URL) == 0 {
+		return fmt.Errorf("Expected non-empty repository URL")
+	}
+
+	helmHomeDir, err := tempArea.NewTempDir("helm-home")
+	if err != nil {
+		return err
+	}
+
+	defer os.RemoveAll(helmHomeDir)
+
+	repo := strings.TrimPrefix(t.opts.Repository.URL, "oci://")
+
+	// TODO authenticate against multiple repos since dependencies might be else where?
+	err = t.login(repo, helmHomeDir)
+	if err != nil {
+		return err
+	}
+
+	ref := fmt.Sprintf("%s/%s:%s", repo, t.opts.Name, t.opts.Version)
+
+	err = t.pull(ref, helmHomeDir)
+	if err != nil {
+		return err
+	}
+
+	err = t.export(ref, dstPath, helmHomeDir)
+	if err != nil {
+		return err
+	}
+
+	// TODO might need to run "helm dependency update"
+
+	return nil
+}
+
+func (t *OCISource) login(repo, helmHomeDir string) error {
+	authArgs, cmdStdin, err := t.addAuthArgs([]string{})
+	if err != nil {
+		return fmt.Errorf("Adding helm auth info: %s", err)
+	}
+
+	if len(authArgs) == 0 {
+		// Skipping authentication
+		return nil
+	}
+
+	args := append([]string{"registry", "login", repo}, authArgs...)
+
+	var stdoutBs, stderrBs bytes.Buffer
+
+	cmd := exec.Command(t.helmBinary, args...)
+	cmd.Env = []string{"HOME=" + helmHomeDir, "HELM_EXPERIMENTAL_OCI=1"}
+	cmd.Stdin = cmdStdin
+	cmd.Stdout = &stdoutBs
+	cmd.Stderr = &stderrBs
+
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Helm registry login: %s (stderr: %s)", err, stderrBs.String())
+	}
+
+	return nil
+}
+
+func (t *OCISource) pull(ref, helmHomeDir string) error {
+	args := []string{"chart", "pull", ref}
+
+	var stdoutBs, stderrBs bytes.Buffer
+
+	cmd := exec.Command(t.helmBinary, args...)
+	cmd.Env = []string{"HOME=" + helmHomeDir, "HELM_EXPERIMENTAL_OCI=1"}
+	cmd.Stdout = &stdoutBs
+	cmd.Stderr = &stderrBs
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Helm chart pull: %s (stderr: %s)", err, stderrBs.String())
+	}
+
+	return nil
+}
+
+func (t *OCISource) export(ref, dstPath, helmHomeDir string) error {
+	args := []string{"chart", "export", ref, "--destination", dstPath}
+
+	var stdoutBs, stderrBs bytes.Buffer
+
+	cmd := exec.Command(t.helmBinary, args...)
+	cmd.Env = []string{"HOME=" + helmHomeDir, "HELM_EXPERIMENTAL_OCI=1"}
+	cmd.Stdout = &stdoutBs
+	cmd.Stderr = &stderrBs
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Helm chart export: %s (stderr: %s)", err, stderrBs.String())
+	}
+
+	return nil
+}
+
+func (t *OCISource) addAuthArgs(args []string) ([]string, io.Reader, error) {
+	var authArgs []string
+	var passwordStdin io.Reader
+
+	if t.opts.Repository != nil && t.opts.Repository.SecretRef != nil {
+		secret, err := t.refFetcher.GetSecret(t.opts.Repository.SecretRef.Name)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for name, val := range secret.Data {
+			switch name {
+			case ctlconf.SecretK8sCorev1BasicAuthUsernameKey:
+				authArgs = append(authArgs, []string{"--username", string(val)}...)
+			case ctlconf.SecretK8sCorev1BasicAuthPasswordKey:
+				authArgs = append(authArgs, []string{"--password-stdin"}...)
+				passwordStdin = strings.NewReader(string(val))
+			default:
+				return nil, nil, fmt.Errorf("Unknown secret field '%s' in secret '%s'", name, secret.Metadata.Name)
+			}
+		}
+	}
+
+	return append(args, authArgs...), passwordStdin, nil
+}

--- a/pkg/vendir/fetch/image/sync.go
+++ b/pkg/vendir/fetch/image/sync.go
@@ -80,6 +80,11 @@ func (t *Sync) addAuthArgs(args []string) ([]string, error) {
 			return nil, err
 		}
 
+		secret, err = secret.ToBasicAuthSecret()
+		if err != nil {
+			return nil, err
+		}
+
 		for name, val := range secret.Data {
 			switch name {
 			case ctlconf.SecretK8sCorev1BasicAuthUsernameKey:

--- a/pkg/vendir/fetch/imgpkgbundle/sync.go
+++ b/pkg/vendir/fetch/imgpkgbundle/sync.go
@@ -79,6 +79,11 @@ func (t *Sync) addAuthArgs(args []string) ([]string, error) {
 			return nil, err
 		}
 
+		secret, err = secret.ToBasicAuthSecret()
+		if err != nil {
+			return nil, err
+		}
+
 		for name, val := range secret.Data {
 			switch name {
 			case ctlconf.SecretK8sCorev1BasicAuthUsernameKey:


### PR DESCRIPTION
this PR includes 3 commits:
- extract http source in helmchart => no change to functionality, just extraction. prep for next commit
- support experimental oci helm charts via oci:// repository url => supports repository.url oci:// schema. uses experimental commands in helm cli. it seems that eventually some of these commands would be merged into other commands.
- support dockerconfigjson secrets for image/imgpkgBundle/helmChart => semi related change to support dockerconfigjson secrets for specifying registry auth

this PR did not add e2e test for oci artifact fetching since it turns out most registries dont support custom artifact types. i could see eventually adding e2e tests against local registry:2, but that seems like a separable issue. meanwhile tested manually against a private registry i had access to.