### PR TITLE
Honor (https?|no)_proxy environment variables for helmChart

### DIFF
--- a/pkg/vendir/fetch/helmchart/http_source.go
+++ b/pkg/vendir/fetch/helmchart/http_source.go
@@ -44,7 +44,7 @@ func (t *HTTPSource) Fetch(dstPath string, tempArea ctlfetch.TempArea) error {
 }
 
 func setEnv(helmHomeDir string) []string {
-	re := regexp.MustCompile(`(?i)^(https?|no)_proxy=.*`)
+	re := regexp.MustCompile(`(?i)\A(https?|no)_proxy=.*`)
 	env := []string{"HOME=" + helmHomeDir}
 	for _, e := range os.Environ() {
 		if re.MatchString(e) {

--- a/pkg/vendir/fetch/helmchart/http_source.go
+++ b/pkg/vendir/fetch/helmchart/http_source.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	ctlconf "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/config"
@@ -42,13 +43,24 @@ func (t *HTTPSource) Fetch(dstPath string, tempArea ctlfetch.TempArea) error {
 	return t.fetch(helmHomeDir, dstPath)
 }
 
+func SetEnv(helmHomeDir string) []string {
+	re := regexp.MustCompile(`(https?|no)_proxy=.*`)
+	env := []string{"HOME=" + helmHomeDir}
+	for _, e := range os.Environ() {
+		if re.MatchString(e) {
+			env = append(env, e)
+		}
+	}
+	return env
+}
+
 func (t *HTTPSource) init(helmHomeDir string) error {
 	args := []string{"init", "--client-only"}
 
 	var stdoutBs, stderrBs bytes.Buffer
 
 	cmd := exec.Command(t.helmBinary, args...)
-	cmd.Env = []string{"HOME=" + helmHomeDir}
+	cmd.Env = SetEnv(helmHomeDir)
 	cmd.Stdout = &stdoutBs
 	cmd.Stderr = &stderrBs
 
@@ -106,7 +118,7 @@ func (t *HTTPSource) fetch(helmHomeDir, chartsPath string) error {
 			var stdoutBs, stderrBs bytes.Buffer
 
 			cmd := exec.Command(t.helmBinary, repoAddArgs...)
-			cmd.Env = []string{"HOME=" + helmHomeDir}
+			cmd.Env = SetEnv(helmHomeDir)
 			cmd.Stdout = &stdoutBs
 			cmd.Stderr = &stderrBs
 
@@ -129,7 +141,8 @@ func (t *HTTPSource) fetch(helmHomeDir, chartsPath string) error {
 	var stdoutBs, stderrBs bytes.Buffer
 
 	cmd := exec.Command(t.helmBinary, fetchArgs...)
-	cmd.Env = []string{"HOME=" + helmHomeDir}
+	cmd.Env = SetEnv(helmHomeDir)
+
 	cmd.Stdout = &stdoutBs
 	cmd.Stderr = &stderrBs
 

--- a/pkg/vendir/fetch/helmchart/http_source.go
+++ b/pkg/vendir/fetch/helmchart/http_source.go
@@ -43,8 +43,8 @@ func (t *HTTPSource) Fetch(dstPath string, tempArea ctlfetch.TempArea) error {
 	return t.fetch(helmHomeDir, dstPath)
 }
 
-func SetEnv(helmHomeDir string) []string {
-	re := regexp.MustCompile(`(https?|no)_proxy=.*`)
+func setEnv(helmHomeDir string) []string {
+	re := regexp.MustCompile(`(?i)^(https?|no)_proxy=.*`)
 	env := []string{"HOME=" + helmHomeDir}
 	for _, e := range os.Environ() {
 		if re.MatchString(e) {
@@ -60,7 +60,7 @@ func (t *HTTPSource) init(helmHomeDir string) error {
 	var stdoutBs, stderrBs bytes.Buffer
 
 	cmd := exec.Command(t.helmBinary, args...)
-	cmd.Env = SetEnv(helmHomeDir)
+	cmd.Env = setEnv(helmHomeDir)
 	cmd.Stdout = &stdoutBs
 	cmd.Stderr = &stderrBs
 
@@ -118,7 +118,7 @@ func (t *HTTPSource) fetch(helmHomeDir, chartsPath string) error {
 			var stdoutBs, stderrBs bytes.Buffer
 
 			cmd := exec.Command(t.helmBinary, repoAddArgs...)
-			cmd.Env = SetEnv(helmHomeDir)
+			cmd.Env = setEnv(helmHomeDir)
 			cmd.Stdout = &stdoutBs
 			cmd.Stderr = &stderrBs
 
@@ -141,7 +141,7 @@ func (t *HTTPSource) fetch(helmHomeDir, chartsPath string) error {
 	var stdoutBs, stderrBs bytes.Buffer
 
 	cmd := exec.Command(t.helmBinary, fetchArgs...)
-	cmd.Env = SetEnv(helmHomeDir)
+	cmd.Env = setEnv(helmHomeDir)
 
 	cmd.Stdout = &stdoutBs
 	cmd.Stderr = &stderrBs


### PR DESCRIPTION
Hello,

The helmChart sync does not honor (https?|no)_proxy environment variables making it impossible to use behind a proxy.

This PR fixes it.

Feel free to comment the code (I don't have a developer background) and I'll do my best to improve it.

Thanks to dkalinin for the help in slack.

Jérémy