### PR TITLE
Rename "carvel-triage" to "carvel triage"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Tell us about a problem you are experiencing
 title: ''
-labels: bug, carvel-triage
+labels: bug, carvel triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for vendir
 title: ''
-labels: carvel-triage, enhancement
+labels: carvel triage, enhancement
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/other-issue.md
+++ b/.github/ISSUE_TEMPLATE/other-issue.md
@@ -2,7 +2,7 @@
 name: Other issue or question
 about: Free form issue or question
 title: ''
-labels: carvel-triage
+labels: carvel triage
 assignees: ''
 
 ---

--- a/.github/workflows/closed-issue-comment.yml
+++ b/.github/workflows/closed-issue-comment.yml
@@ -11,4 +11,4 @@ jobs:
         if: github.event.issue.state == 'closed' && github.event.issue.closed_at != github.event.comment.created_at
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          add-labels: "carvel-triage"
+          add-labels: "carvel triage"

--- a/.github/workflows/closed-issue.yml
+++ b/.github/workflows/closed-issue.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: docker://k8slt/github-labeler-action@sha256:69b376b059806729c25c7d1f6cb0c88e1547eae6f57451414d108915bf4ddffd
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          remove-labels: "carvel-triage"
+          remove-labels: "carvel triage"

--- a/.github/workflows/reopen-issue.yml
+++ b/.github/workflows/reopen-issue.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: docker://k8slt/github-labeler-action@sha256:69b376b059806729c25c7d1f6cb0c88e1547eae6f57451414d108915bf4ddffd
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          add-labels: "carvel-triage"
+          add-labels: "carvel triage"

--- a/.github/workflows/stale-issues-action.yml
+++ b/.github/workflows/stale-issues-action.yml
@@ -16,6 +16,6 @@ jobs:
         stale-issue-message: 'This issue is being marked as stale due to a long period of inactivity and will be closed in 5 days if there is no response.'
         stale-issue-label: 'stale'
         exempt-issue-labels: 'discussion'
-        only-labels: 'carvel-triage'
+        only-labels: 'carvel triage'
         days-before-stale: 40
         days-before-close: 5


### PR DESCRIPTION
To be consistent with other carvel repos. We had a mixed convention for
label names. Given that "good first issue" is a GitHub-wide label, we'll
use spaces over hyphens.

When we merge this PR, we should also rename the label itself in this repo.