### PR TITLE
Add tags to git fetch origin

### DIFF
--- a/pkg/vendir/fetch/git/git.go
+++ b/pkg/vendir/fetch/git/git.go
@@ -147,6 +147,7 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea) error {
 		{"init"},
 		{"config", "credential.helper", "store --file " + gitCredsPath},
 		{"remote", "add", "origin", gitURL},
+		{"config", "remote.origin.tagOpt", "--tags"},
 		{"fetch", "origin"},
 	}
 


### PR DESCRIPTION
This PR adds the [tagOpt](https://git-scm.com/docs/git-config#git-config-remoteltnamegttagOpt) to the git config on checkout.

It is a possible alternative solution to https://github.com/vmware-tanzu/carvel-vendir/issues/45#issuecomment-769180087

<details>
<summary>Output showing successful fetch of keycloak 12.0.1</summary>
❯ vendir sync 
Fetching: components + helmfile/keycloak-operator-12.0.1 (git from git@github.com:keycloak/keycloak-operator.git@12.0.1)

  --> git init
  Initialised empty Git repository in /home/sboardwell/ws/keycloak-test/.vendir-tmp/incoming/git/.git/
  --> git config credential.helper store --file /home/sboardwell/ws/keycloak-test/.vendir-tmp/incoming/git-auth/.git-credentials
  --> git remote add origin git@github.com:keycloak/keycloak-operator.git
  --> git config remote.origin.tagOpt --tags
  --> git fetch origin
  From github.com:keycloak/keycloak-operator
   * [new branch]      10.0.x     -> origin/10.0.x
   * [new branch]      latest     -> origin/latest
   * [new branch]      master     -> origin/master
   * [new tag]         10.0.0     -> 10.0.0
   * [new tag]         10.0.1     -> 10.0.1
   * [new tag]         11.0.0     -> 11.0.0
   * [new tag]         11.0.1     -> 11.0.1
   * [new tag]         11.0.2     -> 11.0.2
   * [new tag]         11.0.3     -> 11.0.3
   * [new tag]         12.0.0     -> 12.0.0
   * [new tag]         12.0.1     -> 12.0.1
   * [new tag]         12.0.2     -> 12.0.2
   * [new tag]         12.0.3     -> 12.0.3
   * [new tag]         12.0.4     -> 12.0.4
   * [new tag]         13.0.0     -> 13.0.0
   * [new tag]         13.0.1     -> 13.0.1
   * [new tag]         14.0.0     -> 14.0.0
   * [new tag]         7.0.1      -> 7.0.1
   * [new tag]         8.0.1      -> 8.0.1
   * [new tag]         8.0.2      -> 8.0.2
   * [new tag]         9.0.0      -> 9.0.0
   * [new tag]         9.0.2      -> 9.0.2
  --> git -c advice.detachedHead=false checkout 12.0.1
  HEAD is now at 3c26d1d Revert "KEYCLOAK-16488 Add AuthZ settings to client CRD"
  --> git submodule update --init --recursive
  --> git rev-parse HEAD
  3c26d1dfc3caaf604397ad0d75934704d14bd717
  --> git describe --tags 3c26d1dfc3caaf604397ad0d75934704d14bd717
  12.0.1
  --> git log -n 1 --pretty=%B 3c26d1dfc3caaf604397ad0d75934704d14bd717
  Revert "KEYCLOAK-16488 Add AuthZ settings to client CRD"
  
  This reverts commit d5fb27b4d916b178758b01d109d0f28c96f82ba1.
  

Lock config

apiVersion: vendir.k14s.io/v1alpha1
directories:
- contents:
  - git:
      commitTitle: Revert "KEYCLOAK-16488 Add AuthZ settings to client CRD"...
      sha: 3c26d1dfc3caaf604397ad0d75934704d14bd717
      tags:
      - 12.0.1
    path: helmfile/keycloak-operator-12.0.1
  path: components
kind: LockConfig

Succeeded
</details>
