### PR TITLE
[hg] set custom configuration options

### DIFF
--- a/pkg/vendir/config/directory.go
+++ b/pkg/vendir/config/directory.go
@@ -70,8 +70,9 @@ type DirectoryContentsGitVerification struct {
 }
 
 type DirectoryContentsHg struct {
-	URL string `json:"url,omitempty"`
-	Ref string `json:"ref,omitempty"`
+	URL  string `json:"url,omitempty"`
+	Ref  string `json:"ref,omitempty"`
+	Hgrc string `json:"hgrc,omitempty"`
 	// Secret may include one or more keys: ssh-privatekey, ssh-knownhosts
 	// +optional
 	SecretRef *DirectoryContentsLocalRef `json:"secretRef,omitempty"`

--- a/pkg/vendir/fetch/hg/hg.go
+++ b/pkg/vendir/fetch/hg/hg.go
@@ -88,7 +88,11 @@ func (t *Hg) fetch(dstPath string, tempArea ctlfetch.TempArea) error {
 		return err
 	}
 
-	var authRc string
+	var hgRc string
+
+	if len(t.opts.Hgrc) > 0 {
+		hgRc = fmt.Sprintf("%s", t.opts.Hgrc)
+	}
 
 	if authOpts.Username != nil && authOpts.Password != nil {
 		if !strings.HasPrefix(hgURL, "https://") {
@@ -99,11 +103,12 @@ func (t *Hg) fetch(dstPath string, tempArea ctlfetch.TempArea) error {
 			return fmt.Errorf("Parsing hg remote url: %s", err)
 		}
 
-		authRc = fmt.Sprintf(`[auth]
+		hgRc = fmt.Sprintf(`%s
+[auth]
 hgauth.prefix = https://%s
 hgauth.username = %s
 hgauth.password = %s
-`, hgCredsURL.Host, *authOpts.Username, *authOpts.Password)
+`, hgRc, hgCredsURL.Host, *authOpts.Username, *authOpts.Password)
 
 	}
 
@@ -134,25 +139,25 @@ hgauth.password = %s
 			sshCmd = append(sshCmd, "-o", "StrictHostKeyChecking=no")
 		}
 
-		authRc = fmt.Sprintf("%s\n[ui]\nssh = %s\n", authRc, strings.Join(sshCmd, " "))
+		hgRc = fmt.Sprintf("%s\n[ui]\nssh = %s\n", hgRc, strings.Join(sshCmd, " "))
 	}
 
-	if (authOpts.Username != nil && authOpts.Password != nil) || authOpts.IsPresent() {
-		credsHgRcPath := filepath.Join(authDir, "hgrc")
-		err = ioutil.WriteFile(credsHgRcPath, []byte(authRc), 0600)
+	if len(hgRc) > 0 {
+		hgRcPath := filepath.Join(authDir, "hgrc")
+		err = ioutil.WriteFile(hgRcPath, []byte(hgRc), 0600)
 		if err != nil {
-			return fmt.Errorf("Writing %s: %s", credsHgRcPath, err)
+			return fmt.Errorf("Writing %s: %s", hgRcPath, err)
 		}
-		env = append(env, "HGRCPATH="+credsHgRcPath)
+		env = append(env, "HGRCPATH="+hgRcPath)
 	}
 
-	hgrcPath := filepath.Join(dstPath, ".hg", "hgrc")
+	repoHgRcPath := filepath.Join(dstPath, ".hg", "hgrc")
 
-	hgRc := fmt.Sprintf("[paths]\ndefault = %s\n", hgURL)
+	repoHgRc := fmt.Sprintf("[paths]\ndefault = %s\n", hgURL)
 
-	err = ioutil.WriteFile(hgrcPath, []byte(hgRc), 0600)
+	err = ioutil.WriteFile(repoHgRcPath, []byte(repoHgRc), 0600)
 	if err != nil {
-		return fmt.Errorf("Writing %s: %s", hgrcPath, err)
+		return fmt.Errorf("Writing %s: %s", repoHgRcPath, err)
 	}
 
 	return t.runMultiple([][]string{


### PR DESCRIPTION
At the moment we cannot use [hg evolve](https://www.mercurial-scm.org/doc/evolution/) with the current version of `vendir` because it require the following lines in hgrc file:

```
[extensions]
evolve =
topic =
```
This pull request add a new option to hg directories named `hgrc` so we can do like following:

```yaml
apiVersion: vendir.k14s.io/v1alpha1
kind: Config
directories:
- path: somewhere
  contents:
  - path: myrepo
    hg:
      url: https://somewhere.io/my/hg/repo
      ref: my-topic
      hgrc: |
        [extensions]
        evolve =
        topic =
      secretRef:
        name: my-auth
```

I'm not sure if:
- this option should be global?
- we should only make a special case for this one and only add an option like `evolve: true`?

Let me know your thoughts.