### PR TITLE
Update hg test lockfile

### DIFF
--- a/examples/hg/vendir.lock.yml
+++ b/examples/hg/vendir.lock.yml
@@ -10,8 +10,8 @@ directories:
       sha: ed2bf9d685dac800fcd02530f3722f4b1c3ffb1a
     path: tag
   - hg:
-      changeSetTitle: '.builds/alpine.yml: upgrade to 3.14'
-      sha: 24906043b09ea11bc9a3bee491ef2f845e96b464
+      changeSetTitle: Correctly set 'pkgver' in Debian build manifest
+      sha: 70074fdce7a252d8433e41b9ad569f5a2bfb6cba
     path: branch
   path: vendor
 kind: LockConfig

--- a/examples/hg/vendor/branch/scss/main.scss
+++ b/examples/hg/vendor/branch/scss/main.scss
@@ -15,7 +15,7 @@
   margin-bottom: 1rem;
 }
 
-pre {
+.event-list pre {
   padding-left: 0;
   padding-right: 0;
   background: transparent;


### PR DESCRIPTION
- The upstream repository has changed
- This was causing the tests to fail due to a diff in sha / commit name