### PR TITLE
dont set IMGPKG_ANON when no auth is explicitly given

### DIFF
--- a/pkg/vendir/fetch/image/imgpkg.go
+++ b/pkg/vendir/fetch/image/imgpkg.go
@@ -120,10 +120,6 @@ func (t *Imgpkg) authEnv() ([]string, error) {
 		}
 	}
 
-	if len(authEnv) == 0 {
-		authEnv = []string{"IMGPKG_ANON=true"}
-	}
-
 	return authEnv, nil
 }
 

--- a/pkg/vendir/fetch/image/imgpkg_test.go
+++ b/pkg/vendir/fetch/image/imgpkg_test.go
@@ -21,9 +21,7 @@ func TestImgpkgAuth(t *testing.T) {
 			Data: map[string][]byte{},
 		})
 
-		requireImgpkgEnv(t, []string{
-			"IMGPKG_ANON=true",
-		}, ranCmd.Env)
+		requireImgpkgEnv(t, nil, ranCmd.Env)
 	})
 
 	t.Run("with filled plain secret", func(t *testing.T) {
@@ -64,9 +62,7 @@ func TestImgpkgAuth(t *testing.T) {
 			},
 		})
 
-		requireImgpkgEnv(t, []string{
-			"IMGPKG_ANON=true",
-		}, ranCmd.Env)
+		requireImgpkgEnv(t, nil, ranCmd.Env)
 	})
 
 	t.Run("with filled dockerconfigjson secret", func(t *testing.T) {
@@ -107,7 +103,7 @@ func TestImgpkgAuth(t *testing.T) {
 		_, err := imgpkg.Run([]string{})
 		require.NoError(t, err)
 
-		requireImgpkgEnv(t, []string{"IMGPKG_ANON=true"}, ranCmd.Env)
+		requireImgpkgEnv(t, nil, ranCmd.Env)
 	})
 }
 


### PR DESCRIPTION
removal of this allow imgpkg to use other auth methods; this is inline with allowing git fetcher to use its regular auth mechanisms even though they are not explicitly called out in vendir.yml