### PR TITLE
Added support for `http` fetch within `githubRelease`

### DIFF
--- a/examples/github-release/vendir.lock.yml
+++ b/examples/github-release/vendir.lock.yml
@@ -13,5 +13,8 @@ directories:
   - githubRelease:
       url: https://api.github.com/repos/cloudfoundry/eirini-release/releases/23064766
     path: github.com/cloudfoundry-incubator/eirini-release
+  - githubRelease:
+      url: https://api.github.com/repos/kubernetes/kubernetes/releases/54824547
+    path: github.com/kubernetes/kubectl
   path: vendor
 kind: LockConfig

--- a/examples/github-release/vendir.yml
+++ b/examples/github-release/vendir.yml
@@ -37,3 +37,13 @@ directories:
         eirini.tgz: b535d9434300e79d11d42acc417148d09054aa32808dab5f12264d3af59ad548
       unpackArchive:
         path: eirini.tgz
+
+  # templates http url with release tag
+  - path: github.com/kubernetes/kubectl
+    githubRelease:
+      slug: kubernetes/kubernetes
+      tagSelection:
+        semver:
+          constraints: "~v1.23.x"
+      http:
+        url: https://dl.k8s.io/release/{tag}/bin/linux/amd64/kubectl

--- a/pkg/vendir/config/directory.go
+++ b/pkg/vendir/config/directory.go
@@ -147,6 +147,9 @@ type DirectoryContentsGithubRelease struct {
 	// Secret may include one key: token
 	// +optional
 	SecretRef *DirectoryContentsLocalRef `json:"secretRef,omitempty"`
+
+	// +optional
+	HTTP *DirectoryContentsHTTP `json:"http,omitempty"`
 }
 
 type DirectoryContentsHelmChart struct {


### PR DESCRIPTION
This change allows the optional use of an `http` section within a `githubRelease` block, which can be used to directly create the URL of the asset to download with metadata from the GitHub release such as the tag name. The `url` parameter of `http` can interpolate the tag of the GitHub release using the `{tag}` token.

This is useful for several use-cases, primarily when a project publishes GitHub releases but does not include files as assets directly. It will also provide a solution for #145.

Example usage:

```
apiVersion: vendir.k14s.io/v1alpha1
kind: Config
directories:
- path: vendor
  contents:
  # templates http url with release tag
  - path: github.com/kubernetes/kubectl
    githubRelease:
      slug: kubernetes/kubernetes
      tagSelection:
        semver:
          constraints: "~v1.23.x"
      http:
        url: https://dl.k8s.io/release/{tag}/bin/linux/amd64/kubectl
```