### PR TITLE
Setting buildid is no longer necessary for reproducible builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,6 @@ builds:
       - -trimpath
 
     ldflags:
-      - -buildid=
       - -X github.com/vmware-tanzu/carvel-vendir/pkg/vendir/version.Version={{ .Version }}
 
 archives:

--- a/hack/build-binaries.sh
+++ b/hack/build-binaries.sh
@@ -10,7 +10,7 @@ VERSION="${1:-`get_latest_git_tag`}"
 
 # makes builds reproducible
 export CGO_ENABLED=0
-LDFLAGS="-X github.com/vmware-tanzu/carvel-vendir/pkg/vendir/version.Version=$VERSION -buildid="
+LDFLAGS="-X github.com/vmware-tanzu/carvel-vendir/pkg/vendir/version.Version=$VERSION"
 repro_flags="-trimpath -mod=vendor"
 
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -6,7 +6,7 @@ VERSION="${1:-0.0.0+develop}"
 
 # makes builds reproducible
 export CGO_ENABLED=0
-LDFLAGS="-X github.com/vmware-tanzu/carvel-vendir/pkg/vendir/version.Version=$VERSION -buildid="
+LDFLAGS="-X github.com/vmware-tanzu/carvel-vendir/pkg/vendir/version.Version=$VERSION"
 repro_flags="-trimpath -mod=vendor"
 
 go mod vendor


### PR DESCRIPTION
Fixed in https://github.com/golang/go/commit/aa680c0c49b55722a72ad3772e590cd2f9af541d