### PR TITLE
Bump golang from 1.17 -> 1.18

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,10 +12,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go 1.17
+      - name: Install Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.0
+          go-version: 1.18.0
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5e15885530fb01d81d1f24e8a6f54ebbd0fed7eb
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v1
       with:
-        go-version: "1.17"
+        go-version: "1.18"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
       with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       repo: vmware-tanzu/carvel-vendir
       tool: vendir
-      goVersion: 1.17.0
+      goVersion: 1.18.0
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       slackWebhookURL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/carvel-vendir
 
-go 1.17
+go 1.18
 
 require (
 	github.com/bmatcuk/doublestar v1.2.1


### PR DESCRIPTION
- Ran: 'go mod edit -go=1.18'
- Replaced 1.17 -> 1.18 found in github actions