### PR TITLE
[hg] fault tolerant commit sha resolution

### DIFF
--- a/pkg/vendir/fetch/hg/hg.go
+++ b/pkg/vendir/fetch/hg/hg.go
@@ -48,8 +48,8 @@ func (t *Hg) Retrieve(dstPath string, tempArea ctlfetch.TempArea) (HgInfo, error
 
 	info := HgInfo{}
 
-	// add --debug for full changeset id instead of short
-	out, _, err := t.run([]string{"id", "-i", "--debug"}, nil, dstPath)
+	// use hg log to retrieve full cset sha
+	out, _, err := t.run([]string{"log", "-r", ".", "-T", "{node}"}, nil, dstPath)
 	if err != nil {
 		return HgInfo{}, err
 	}


### PR DESCRIPTION
if `terminfo` is wrongly configured `hg id -i --debug` can return the following errors:

```
no terminfo entry for invis
no terminfo entry for blink
no terminfo entry for invis
no terminfo entry for blink
no terminfo entry for invis
```
Which causes vendir to fail to retrieve the commit sha.

Using `hg log -r . -T '{node}'` returns the same result and solves this issue.