### PR TITLE
Avoid writing the lock config file if there are no changes

### DIFF
--- a/pkg/vendir/cmd/sync.go
+++ b/pkg/vendir/cmd/sync.go
@@ -97,9 +97,8 @@ func (o *SyncOptions) Run() error {
 
 	// If syncing against a lock file, apply lock information
 	// on top of existing config
-	var existingLockConfig ctlconf.LockConfig
 	if o.Locked {
-		existingLockConfig, err = ctlconf.NewLockConfigFromFile(o.LockFile)
+		existingLockConfig, err := ctlconf.NewLockConfigFromFile(o.LockFile)
 		if err != nil {
 			return err
 		}
@@ -177,9 +176,6 @@ func (o *SyncOptions) Run() error {
 		return nil
 	}
 
-	if newLockConfig.IsEqualTo(existingLockConfig) {
-		return nil
-	}
 	return newLockConfig.WriteToFile(o.LockFile)
 }
 

--- a/pkg/vendir/cmd/sync.go
+++ b/pkg/vendir/cmd/sync.go
@@ -97,8 +97,9 @@ func (o *SyncOptions) Run() error {
 
 	// If syncing against a lock file, apply lock information
 	// on top of existing config
+	var existingLockConfig ctlconf.LockConfig
 	if o.Locked {
-		existingLockConfig, err := ctlconf.NewLockConfigFromFile(o.LockFile)
+		existingLockConfig, err = ctlconf.NewLockConfigFromFile(o.LockFile)
 		if err != nil {
 			return err
 		}
@@ -176,6 +177,9 @@ func (o *SyncOptions) Run() error {
 		return nil
 	}
 
+	if newLockConfig.IsEqualTo(existingLockConfig) {
+		return nil
+	}
 	return newLockConfig.WriteToFile(o.LockFile)
 }
 

--- a/pkg/vendir/config/lock_config.go
+++ b/pkg/vendir/config/lock_config.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -142,4 +143,10 @@ func (c LockConfig) MergeContents(path string, replaceCon LockDirectoryContents)
 		return fmt.Errorf("Expected to match exactly one directory, but did not match any")
 	}
 	return nil
+}
+
+func (c LockConfig) IsEqualTo(other LockConfig) bool {
+	myBytes, _ := c.AsBytes()
+	yourBytes, _ := other.AsBytes()
+	return bytes.Compare(myBytes, yourBytes) == 0
 }

--- a/pkg/vendir/config/lock_config_test.go
+++ b/pkg/vendir/config/lock_config_test.go
@@ -142,6 +142,7 @@ func TestWriteToFile(t *testing.T) {
 
 		// Check that the file contents have been updated
 		updatedBytes, err := os.ReadFile(lockFilePath)
+		require.NoError(t, err)
 		require.Equal(t, updatedBytes, lockConfigBytes)
 	})
 

--- a/pkg/vendir/config/lock_config_test.go
+++ b/pkg/vendir/config/lock_config_test.go
@@ -1,0 +1,150 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/vmware-tanzu/carvel-vendir/pkg/vendir/config"
+	"testing"
+)
+
+func TestNewLockConfigFromBytes(t *testing.T) {
+	t.Run("invalid yaml returns an error", func(t *testing.T) {
+		invalidYaml := "this !== valid yaml"
+		_, err := config.NewLockConfigFromBytes([]byte(invalidYaml))
+		require.EqualError(t, err, "Unmarshaling lock config: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type config.LockConfig")
+	})
+
+	t.Run("valid yaml, but not valid lock config returns an error", func(t *testing.T) {
+		invalidYaml := "apiVersion: not.the.right.apiVersion"
+		_, err := config.NewLockConfigFromBytes([]byte(invalidYaml))
+		require.EqualError(t, err, "Validating lock config: Validating apiVersion: Unknown version (known: vendir.k14s.io/v1alpha1)")
+	})
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("valid object returns no error", func(t *testing.T) {
+		lockConfig := config.LockConfig{
+			APIVersion:  "vendir.k14s.io/v1alpha1",
+			Kind:        "LockConfig",
+			Directories: []config.LockDirectory{},
+		}
+		require.NoError(t, lockConfig.Validate())
+	})
+	t.Run("invalid API Version returns an error", func(t *testing.T) {
+		lockConfig := config.LockConfig{
+			APIVersion:  "what.in.the.world.is.that.thing",
+			Kind:        "LockConfig",
+			Directories: []config.LockDirectory{},
+		}
+		require.EqualError(t, lockConfig.Validate(), "Validating apiVersion: Unknown version (known: vendir.k14s.io/v1alpha1)")
+	})
+	t.Run("invalid kind returns an error", func(t *testing.T) {
+		lockConfig := config.LockConfig{
+			APIVersion:  "vendir.k14s.io/v1alpha1",
+			Kind:        "LockedConfig",
+			Directories: []config.LockDirectory{},
+		}
+		require.EqualError(t, lockConfig.Validate(), "Validating kind: Unknown kind (known: LockConfig)")
+	})
+}
+
+func TestIsEqualTo(t *testing.T) {
+	gitAndDirLockConfig := config.LockConfig{
+		APIVersion: "vendir.k14s.io/v1alpha1",
+		Kind:       "LockConfig",
+		Directories: []config.LockDirectory{
+			{
+				Path: "lockpath",
+				Contents: []config.LockDirectoryContents{
+					{
+						Path: "gitpath",
+						Git: &config.LockDirectoryContentsGit{
+							SHA:         "mygitsha",
+							Tags:        []string{"main"},
+							CommitTitle: "mycommittitle",
+						},
+					},
+					{
+						Path:      "dirpath",
+						Directory: &config.LockDirectoryContentsDirectory{},
+					},
+				},
+			},
+		},
+	}
+	sameGitAndDirLockConfig := config.LockConfig{
+		APIVersion: "vendir.k14s.io/v1alpha1",
+		Kind:       "LockConfig",
+		Directories: []config.LockDirectory{
+			{
+				Path: "lockpath",
+				Contents: []config.LockDirectoryContents{
+					{
+						Path: "gitpath",
+						Git: &config.LockDirectoryContentsGit{
+							SHA:         "mygitsha",
+							Tags:        []string{"main"},
+							CommitTitle: "mycommittitle",
+						},
+					},
+					{
+						Path:      "dirpath",
+						Directory: &config.LockDirectoryContentsDirectory{},
+					},
+				},
+			},
+		},
+	}
+	sortedGitAndDirLockConfig := config.LockConfig{
+		APIVersion: "vendir.k14s.io/v1alpha1",
+		Kind:       "LockConfig",
+		Directories: []config.LockDirectory{
+			{
+				Path: "lockpath",
+				Contents: []config.LockDirectoryContents{
+					{
+						Path:      "dirpath",
+						Directory: &config.LockDirectoryContentsDirectory{},
+					},
+					{
+						Path: "gitpath",
+						Git: &config.LockDirectoryContentsGit{
+							SHA:         "mygitsha",
+							Tags:        []string{"main"},
+							CommitTitle: "mycommittitle",
+						},
+					},
+				},
+			},
+		},
+	}
+	httpLockConfig := config.LockConfig{
+		APIVersion: "vendir.k14s.io/v1alpha1",
+		Kind:       "LockConfig",
+		Directories: []config.LockDirectory{
+			{
+				Path: "lockpath",
+				Contents: []config.LockDirectoryContents{
+					{
+						Path: "httppath",
+						HTTP: &config.LockDirectoryContentsHTTP{},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("equal lock configs returns true", func(t *testing.T) {
+		require.True(t, gitAndDirLockConfig.IsEqualTo(sameGitAndDirLockConfig))
+	})
+
+	t.Run("equal lock configs, but different ordering, returns false", func(t *testing.T) {
+		require.False(t, gitAndDirLockConfig.IsEqualTo(sortedGitAndDirLockConfig))
+	})
+
+	t.Run("not equal lock configs returns false", func(t *testing.T) {
+		require.False(t, gitAndDirLockConfig.IsEqualTo(httpLockConfig))
+	})
+}

--- a/test/e2e/example.go
+++ b/test/e2e/example.go
@@ -113,9 +113,23 @@ func (et example) check(t *testing.T, vendir Vendir) error {
 		}
 	}
 
+	lockFileStat, err := os.Stat(filepath.Join(path, "vendir.lock.yml"))
+	if err != nil {
+		return fmt.Errorf("Expected no err for getting lock file stats")
+	}
+
 	_, err = vendir.RunWithOpts([]string{"sync", "--locked"}, RunOpts{Dir: path, Env: et.Env})
 	if err != nil {
 		return fmt.Errorf("Expected no err for sync locked")
+	}
+
+	newLockFileStat, err := os.Stat(filepath.Join(path, "vendir.lock.yml"))
+	if err != nil {
+		return fmt.Errorf("Expected no err for getting lock file stats")
+	}
+
+	if lockFileStat.ModTime() != newLockFileStat.ModTime() {
+		return fmt.Errorf("Expected lock file to not be updated")
 	}
 
 	gitOut := gitDiffExamplesDir(t, path, tmpDir)

--- a/test/e2e/example.go
+++ b/test/e2e/example.go
@@ -114,9 +114,7 @@ func (et example) check(t *testing.T, vendir Vendir) error {
 	}
 
 	lockFileStat, err := os.Stat(filepath.Join(path, "vendir.lock.yml"))
-	if err != nil {
-		return fmt.Errorf("Expected no err for getting lock file stats")
-	}
+	require.NoError(t, err, "Expected no err for getting lock file stats")
 
 	_, err = vendir.RunWithOpts([]string{"sync", "--locked"}, RunOpts{Dir: path, Env: et.Env})
 	if err != nil {
@@ -124,13 +122,8 @@ func (et example) check(t *testing.T, vendir Vendir) error {
 	}
 
 	newLockFileStat, err := os.Stat(filepath.Join(path, "vendir.lock.yml"))
-	if err != nil {
-		return fmt.Errorf("Expected no err for getting lock file stats")
-	}
-
-	if lockFileStat.ModTime() != newLockFileStat.ModTime() {
-		return fmt.Errorf("Expected lock file to not be updated")
-	}
+	require.NoError(t, err, "Expected no err for getting new lock file stats")
+	require.Equal(t, lockFileStat.ModTime(), newLockFileStat.ModTime(), "Expected lock file to not be updated")
 
 	gitOut := gitDiffExamplesDir(t, path, tmpDir)
 	if gitOut != "" {

--- a/test/e2e/example_locked_test.go
+++ b/test/e2e/example_locked_test.go
@@ -40,7 +40,7 @@ func TestExampleLocked(t *testing.T) {
 		t.Fatalf("Expected no err")
 	}
 
-	// add file that shouldnt exist
+	// add file that shouldn't exist
 	err = os.WriteFile(path+"/vendor/github.com/cloudfoundry/extra/extra", []byte("extra"), 0600)
 	if err != nil {
 		t.Fatalf("Expected no err")


### PR DESCRIPTION
When using `vendir sync -l`, if the lock file did not change, then do not write the lock file.

This preserves the original modified time, which makes it work much better with tools like Make.

Signed-off-by: Pete Wall <pwall@vmware.com>