### PR TITLE
Bump `imgpkg` to version 0.33.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.0
-	github.com/vmware-tanzu/carvel-imgpkg v0.32.0
+	github.com/vmware-tanzu/carvel-imgpkg v0.33.0
 	golang.org/x/crypto v0.0.0-20211202192323-5770296d904e
 	golang.org/x/oauth2 v0.0.0-20220718184931-c8730f7fcb92
 	golang.org/x/tools v0.1.11

--- a/go.sum
+++ b/go.sum
@@ -858,8 +858,8 @@ github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaW
 github.com/viki-org/dnscache v0.0.0-20130720023526-c70c1f23c5d8/go.mod h1:dniwbG03GafCjFohMDmz6Zc6oCuiqgH6tGNyXTkHzXE=
 github.com/vito/go-interact v1.0.1 h1:O8xi8c93bRUv2Tb/v6HdiuGc+WnWt+AQzF74MOOdlBs=
 github.com/vito/go-interact v1.0.1/go.mod h1:HrdHSJXD2yn1MhlTwSIMeFgQ5WftiIorszVGd3S/DAA=
-github.com/vmware-tanzu/carvel-imgpkg v0.32.0 h1:J7+4bG8bhpZMRt+FfOgY2otxR2hp3Qcp+yXObZxPZHc=
-github.com/vmware-tanzu/carvel-imgpkg v0.32.0/go.mod h1:lezdty3a/o/weRWbn/yRX7d8lNSO8vY1fMMq5QKBwqY=
+github.com/vmware-tanzu/carvel-imgpkg v0.33.0 h1:ZfMeJ+PKXJkkxcRSRiI/N9Vzxgyqj7YWktY3BEgQC84=
+github.com/vmware-tanzu/carvel-imgpkg v0.33.0/go.mod h1:9J2sqH4lTws2fPhiloEWTc7tKvdsmmOxRqEWgMokTXM=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/v1/tag.go
+++ b/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/v1/tag.go
@@ -1,0 +1,69 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	regname "github.com/google/go-containerregistry/pkg/name"
+	"github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/registry"
+)
+
+// TagInfo Contains the tag name and the digest associated with the tag
+// TagInfo.Digest might be empty if caller ask for it not to be retrieved
+type TagInfo struct {
+	Tag    string
+	Digest string
+}
+
+// TagsInfo Contains all the tags associated with the repository on Image
+type TagsInfo struct {
+	Repository string
+	Tags       []TagInfo
+}
+
+// TagList Retrieve all the tags associated with a repository
+// imageRef contains the address for the repository
+// getDigests when set to true, provides
+func TagList(imageRef string, getDigests bool, registryOpts registry.Opts) (TagsInfo, error) {
+	reg, err := registry.NewSimpleRegistry(registryOpts)
+	if err != nil {
+		return TagsInfo{}, err
+	}
+
+	ref, err := regname.ParseReference(imageRef, regname.WeakValidation)
+	if err != nil {
+		return TagsInfo{}, err
+	}
+
+	tags, err := reg.ListTags(ref.Context())
+	if err != nil {
+		return TagsInfo{}, err
+	}
+
+	tagList := TagsInfo{
+		Repository: ref.Context().String(),
+	}
+
+	for _, tag := range tags {
+		tagInfo := TagInfo{
+			Tag: tag,
+		}
+
+		if getDigests {
+			tagRef, err := regname.NewTag(ref.Context().String()+":"+tag, regname.WeakValidation)
+			if err != nil {
+				return TagsInfo{}, err
+			}
+
+			hash, err := reg.Digest(tagRef)
+			if err != nil {
+				return TagsInfo{}, err
+			}
+
+			tagInfo.Digest = hash.String()
+		}
+		tagList.Tags = append(tagList.Tags, tagInfo)
+	}
+
+	return tagList, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -359,8 +359,8 @@ github.com/vbatts/tar-split/archive/tar
 # github.com/vito/go-interact v1.0.1
 ## explicit; go 1.12
 github.com/vito/go-interact/interact
-# github.com/vmware-tanzu/carvel-imgpkg v0.32.0
-## explicit; go 1.18
+# github.com/vmware-tanzu/carvel-imgpkg v0.33.0
+## explicit; go 1.19
 github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/bundle
 github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/image
 github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/imagedesc


### PR DESCRIPTION
- Update call to tag in `imgpkg` to be done via API call. This change will make `vendir` not depend on `imgpkg` being installed in the machine.