### PR TITLE
Make directory permissions configurable

### DIFF
--- a/pkg/vendir/config/directory.go
+++ b/pkg/vendir/config/directory.go
@@ -29,7 +29,7 @@ type Directory struct {
 	Path     string              `json:"path"`
 	Contents []DirectoryContents `json:"contents,omitempty"`
 
-	Permission *os.FileMode `json:"permission,omitempty"`
+	Permissions *os.FileMode `json:"permissions,omitempty"`
 }
 
 type DirectoryContents struct {
@@ -55,7 +55,7 @@ type DirectoryContents struct {
 
 	NewRootPath string `json:"newRootPath,omitempty"`
 
-	Permission *os.FileMode `json:"permission,omitempty"`
+	Permissions *os.FileMode `json:"permissions,omitempty"`
 }
 
 type DirectoryContentsGit struct {

--- a/pkg/vendir/config/directory.go
+++ b/pkg/vendir/config/directory.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	ctlver "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1"
@@ -27,6 +28,8 @@ var (
 type Directory struct {
 	Path     string              `json:"path"`
 	Contents []DirectoryContents `json:"contents,omitempty"`
+
+	Permission *os.FileMode `json:"permission,omitempty"`
 }
 
 type DirectoryContents struct {
@@ -51,6 +54,8 @@ type DirectoryContents struct {
 	LegalPaths *[]string `json:"legalPaths,omitempty"`
 
 	NewRootPath string `json:"newRootPath,omitempty"`
+
+	Permission *os.FileMode `json:"permission,omitempty"`
 }
 
 type DirectoryContentsGit struct {

--- a/pkg/vendir/directory/directory.go
+++ b/pkg/vendir/directory/directory.go
@@ -210,7 +210,7 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 		// after everything else is done, ensure the inner dir's access perms are set
 		// chmod to the content's permission, fall back to the directory's
-		err = maybeChmod(stagingDstPath, contents.Permission, d.opts.Permission)
+		err = maybeChmod(stagingDstPath, contents.Permissions, d.opts.Permissions)
 		if err != nil {
 			return lockConfig, fmt.Errorf("chmod on '%s': %s", stagingDstPath, err)
 		}
@@ -224,7 +224,7 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 	}
 
 	// after everything else is done, ensure the outer dir's access perms are set
-	err = maybeChmod(d.opts.Path, d.opts.Permission)
+	err = maybeChmod(d.opts.Path, d.opts.Permissions)
 	if err != nil {
 		return lockConfig, fmt.Errorf("chmod on '%s': %s", d.opts.Path, err)
 	}

--- a/test/e2e/directory_permissions_test.go
+++ b/test/e2e/directory_permissions_test.go
@@ -35,7 +35,7 @@ func TestDirectoryPermissions(t *testing.T) {
 				c.Directories[0].Permission = p(0744)
 			},
 			expectedPerms: filePerms{
-				"dir-0": 0744, filepath.Join("dir-0", "subdir-0-0"): 0700, filepath.Join("dir-0", "subdir-0-1"): 0700,
+				"dir-0": 0744, filepath.Join("dir-0", "subdir-0-0"): 0744, filepath.Join("dir-0", "subdir-0-1"): 0744,
 				"dir-1": 0700, filepath.Join("dir-1", "subdir-1-0"): 0700, filepath.Join("dir-1", "subdir-1-1"): 0700,
 			},
 		},
@@ -46,6 +46,17 @@ func TestDirectoryPermissions(t *testing.T) {
 			},
 			expectedPerms: filePerms{
 				"dir-0": 0700, filepath.Join("dir-0", "subdir-0-0"): 0755, filepath.Join("dir-0", "subdir-0-1"): 0744,
+				"dir-1": 0700, filepath.Join("dir-1", "subdir-1-0"): 0700, filepath.Join("dir-1", "subdir-1-1"): 0700,
+			},
+		},
+		"blocking write or execute in (sub)dirs still works": {
+			updateConfig: func(c *config.Config) {
+				c.Directories[0].Permission = p(0100) // we still need exec permissions here, so that we can stat its subdirectories
+				c.Directories[0].Contents[0].Permission = p(0000)
+				c.Directories[0].Contents[1].Permission = p(0004)
+			},
+			expectedPerms: filePerms{
+				"dir-0": 0100, filepath.Join("dir-0", "subdir-0-0"): 0000, filepath.Join("dir-0", "subdir-0-1"): 0004,
 				"dir-1": 0700, filepath.Join("dir-1", "subdir-1-0"): 0700, filepath.Join("dir-1", "subdir-1-1"): 0700,
 			},
 		},

--- a/test/e2e/directory_permissions_test.go
+++ b/test/e2e/directory_permissions_test.go
@@ -32,7 +32,7 @@ func TestDirectoryPermissions(t *testing.T) {
 		},
 		"outer dir permissions can be configured": {
 			updateConfig: func(c *config.Config) {
-				c.Directories[0].Permission = p(0744)
+				c.Directories[0].Permissions = p(0744)
 			},
 			expectedPerms: filePerms{
 				"dir-0": 0744, filepath.Join("dir-0", "subdir-0-0"): 0744, filepath.Join("dir-0", "subdir-0-1"): 0744,
@@ -41,8 +41,8 @@ func TestDirectoryPermissions(t *testing.T) {
 		},
 		"inner dir permissions can be configured": {
 			updateConfig: func(c *config.Config) {
-				c.Directories[0].Contents[0].Permission = p(0755)
-				c.Directories[0].Contents[1].Permission = p(0744)
+				c.Directories[0].Contents[0].Permissions = p(0755)
+				c.Directories[0].Contents[1].Permissions = p(0744)
 			},
 			expectedPerms: filePerms{
 				"dir-0": 0700, filepath.Join("dir-0", "subdir-0-0"): 0755, filepath.Join("dir-0", "subdir-0-1"): 0744,
@@ -51,9 +51,9 @@ func TestDirectoryPermissions(t *testing.T) {
 		},
 		"blocking write or execute in (sub)dirs still works": {
 			updateConfig: func(c *config.Config) {
-				c.Directories[0].Permission = p(0100) // we still need exec permissions here, so that we can stat its subdirectories
-				c.Directories[0].Contents[0].Permission = p(0000)
-				c.Directories[0].Contents[1].Permission = p(0004)
+				c.Directories[0].Permissions = p(0100) // we still need exec permissions here, so that we can stat its subdirectories
+				c.Directories[0].Contents[0].Permissions = p(0000)
+				c.Directories[0].Contents[1].Permissions = p(0004)
 			},
 			expectedPerms: filePerms{
 				"dir-0": 0100, filepath.Join("dir-0", "subdir-0-0"): 0000, filepath.Join("dir-0", "subdir-0-1"): 0004,

--- a/test/e2e/directory_permissions_test.go
+++ b/test/e2e/directory_permissions_test.go
@@ -1,0 +1,140 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware-tanzu/carvel-vendir/pkg/vendir/config"
+	"sigs.k8s.io/yaml"
+)
+
+type filePerms map[string]os.FileMode
+
+type testCases = map[string]struct {
+	updateConfig  func(cfg *config.Config)
+	expectedPerms filePerms
+}
+
+func TestDirectoryPermissions(t *testing.T) {
+	env := BuildEnv(t)
+	vendir := Vendir{t, env.BinaryPath, Logger{}}
+
+	tCases := testCases{
+		"no permissions defined": {
+			expectedPerms: filePerms{
+				"dir-0": 0700, filepath.Join("dir-0", "subdir-0-0"): 0700, filepath.Join("dir-0", "subdir-0-1"): 0700,
+				"dir-1": 0700, filepath.Join("dir-1", "subdir-1-0"): 0700, filepath.Join("dir-1", "subdir-1-1"): 0700,
+			},
+		},
+	}
+
+	for tName, tCase := range tCases {
+		t.Run(tName, func(t *testing.T) {
+			cfg := defaultConfig()
+
+			if u := tCase.updateConfig; u != nil {
+				u(cfg)
+			}
+
+			actualPerms := runAndGetActualPerms(t, vendir, *cfg)
+			tCase.expectedPerms.validate(t, actualPerms)
+		})
+	}
+}
+
+func p(p os.FileMode) *os.FileMode { return &p }
+
+func (expected filePerms) validate(t *testing.T, actual filePerms) {
+	for path, expectedPerms := range expected {
+		actualPerms, ok := actual[path]
+		assert.True(t, ok, "no actual permissions for path %s found", path)
+		assert.Equal(t, expectedPerms, actualPerms, "expected permissions for '%s' to be '%s', but got '%s'", path, expectedPerms, actualPerms)
+	}
+}
+
+func writeConfigFile(t *testing.T, tmpDir string, config config.Config) {
+	configPath := filepath.Join(tmpDir, "vendir.yml")
+	bytes, err := yaml.Marshal(config)
+	require.NoError(t, err, "marshalling vendir config")
+	err = os.WriteFile(configPath, bytes, 0600)
+	require.NoError(t, err, "writing vendir config")
+}
+
+func runAndGetActualPerms(t *testing.T, vendir Vendir, config config.Config) filePerms {
+	tmpDir, err := os.MkdirTemp("", "vendir-test-")
+	require.NoError(t, err, "creating tmpdir")
+	defer os.RemoveAll(tmpDir)
+
+	writeConfigFile(t, tmpDir, config)
+
+	_, err = vendir.RunWithOpts([]string{"sync"}, RunOpts{Dir: tmpDir, AllowError: true})
+	require.NoError(t, err, "running vendir")
+
+	paths := []string{
+		"dir-0",
+		filepath.Join("dir-0", "subdir-0-0"),
+		filepath.Join("dir-0", "subdir-0-1"),
+		"dir-1",
+		filepath.Join("dir-1", "subdir-1-0"),
+		filepath.Join("dir-1", "subdir-1-1"),
+	}
+
+	perms := filePerms{}
+
+	for _, p := range paths {
+		perms[p] = getPerms(t, filepath.Join(tmpDir, p))
+	}
+
+	return perms
+}
+
+func getPerms(t *testing.T, fileOrDir string) os.FileMode {
+	stat, err := os.Stat(fileOrDir)
+	require.NoError(t, err, "getting stats for %s", fileOrDir)
+	return stat.Mode().Perm()
+}
+
+func defaultConfig() *config.Config {
+	return &config.Config{
+		APIVersion: "vendir.k14s.io/v1alpha1",
+		Kind:       "Config",
+		Directories: []config.Directory{
+			{
+				Path: "dir-0",
+				Contents: []config.DirectoryContents{
+					{Path: "subdir-0-0",
+						Inline: &config.DirectoryContentsInline{
+							Paths: map[string]string{"bar.yml": "bar-0-0"},
+						},
+					},
+					{Path: "subdir-0-1",
+						Inline: &config.DirectoryContentsInline{
+							Paths: map[string]string{"bar.yml": "bar-0-1"},
+						},
+					},
+				},
+			},
+			{
+				Path: "dir-1",
+				Contents: []config.DirectoryContents{
+					{Path: "subdir-1-0",
+						Inline: &config.DirectoryContentsInline{
+							Paths: map[string]string{"bar.yml": "bar-1-0"},
+						},
+					},
+					{Path: "subdir-1-1",
+						Inline: &config.DirectoryContentsInline{
+							Paths: map[string]string{"bar.yml": "bar-1-1"},
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
- Inner directories inherit permissions from the outer directory
- the permissions on the directories is changed late, so that pulling in content is not blocked

/xref: https://github.com/vmware-tanzu/carvel-vendir/issues/186