### PR TITLE
Revert bump of imgpkg to version 0.33.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
-	github.com/vmware-tanzu/carvel-imgpkg v0.35.0
+	github.com/vmware-tanzu/carvel-imgpkg v0.33.1
 	golang.org/x/crypto v0.3.0
 	golang.org/x/oauth2 v0.1.0
 	golang.org/x/tools v0.1.12

--- a/go.sum
+++ b/go.sum
@@ -336,8 +336,8 @@ github.com/vbatts/tar-split v0.11.2 h1:Via6XqJr0hceW4wff3QRzD5gAk/tatMw/4ZA7cTlI
 github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaWq6kXyQ3VI=
 github.com/vito/go-interact v1.0.1 h1:O8xi8c93bRUv2Tb/v6HdiuGc+WnWt+AQzF74MOOdlBs=
 github.com/vito/go-interact v1.0.1/go.mod h1:HrdHSJXD2yn1MhlTwSIMeFgQ5WftiIorszVGd3S/DAA=
-github.com/vmware-tanzu/carvel-imgpkg v0.35.0 h1:53TEf9BJDi9XfjK9RBTTkGi3i+aBvyoNGJlVtrFDDdE=
-github.com/vmware-tanzu/carvel-imgpkg v0.35.0/go.mod h1:MfSRezChCXIBiF0ZK73z0V2WhQW3dkGBbdZHVT9G3Dw=
+github.com/vmware-tanzu/carvel-imgpkg v0.33.1 h1:/zmdnl6HZzadbdXNR3BLkGUCvUhEjAlus9eap5dt/CA=
+github.com/vmware-tanzu/carvel-imgpkg v0.33.1/go.mod h1:9J2sqH4lTws2fPhiloEWTc7tKvdsmmOxRqEWgMokTXM=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/bundle/fetch_images.go
+++ b/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/bundle/fetch_images.go
@@ -8,7 +8,6 @@ import (
 
 	regname "github.com/google/go-containerregistry/pkg/name"
 	"github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/lockconfig"
-	"github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/signature"
 )
 
 // SignatureFetcher Interface to retrieve signatures associated with Images
@@ -32,15 +31,7 @@ func (o *Bundle) FetchAllImagesRefs(concurrency int, ui Logger, sigFetcher Signa
 		}
 		refs, err := sigFetcher.FetchForImageRefs(imgs)
 		if err != nil {
-			fetchErr, ok := err.(*signature.FetchError)
-			if !ok {
-				return nil, err
-			}
-			for _, err := range fetchErr.AllErrors {
-				bundle.cachedImageRefs.StoreImageRef(
-					NewImageRefWithTypeAndError(
-						lockconfig.ImageRef{Image: err.ImageRef()}, SignatureImage, err.Error()))
-			}
+			return nil, err
 		}
 
 		for _, ref := range refs {

--- a/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/bundle/images_refs.go
+++ b/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/bundle/images_refs.go
@@ -20,7 +20,6 @@ type ImageRef struct {
 	IsBundle  *bool
 	Copiable  bool
 	ImageType ImageType
-	Error     string
 }
 
 // ImageType defines the type of Image. This is an evolving list that might grow with time
@@ -49,18 +48,16 @@ func NewContentImageRef(imgRef lockconfig.ImageRef) ImageRef {
 
 // NewImageRefWithType Constructs a new ImageRef based on the ImageType
 func NewImageRefWithType(imgRef lockconfig.ImageRef, imageType ImageType) ImageRef {
-	copiable := imageType == InternalImage
-	isBundle := imageType == BundleImage
+	copiable := true
+	if imageType == InternalImage {
+		copiable = false
+	}
+	isBundle := false
+	if imageType == BundleImage {
+		isBundle = true
+	}
 
 	return ImageRef{ImageRef: imgRef, IsBundle: &isBundle, Copiable: copiable, ImageType: imageType}
-}
-
-// NewImageRefWithTypeAndError Constructs a new ImageRef based on the ImageType that failed to fetch
-func NewImageRefWithTypeAndError(imgRef lockconfig.ImageRef, imageType ImageType, err string) ImageRef {
-	copiable := imageType == InternalImage
-	isBundle := imageType == BundleImage
-
-	return ImageRef{ImageRef: imgRef, IsBundle: &isBundle, Copiable: copiable, ImageType: imageType, Error: err}
 }
 
 // Digest Image Digest
@@ -84,7 +81,6 @@ func (i ImageRef) DeepCopy() ImageRef {
 		IsBundle:  isBundle,
 		Copiable:  i.Copiable,
 		ImageType: i.ImageType,
-		Error:     i.Error,
 	}
 }
 

--- a/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/imagedesc/described_compressed_layer.go
+++ b/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/imagedesc/described_compressed_layer.go
@@ -1,7 +1,6 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package imagedesc defines the description of image, indexes and layers used by go-containerregistry
 package imagedesc
 
 import (

--- a/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/imagedigest/imagedigest.go
+++ b/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/imagedigest/imagedigest.go
@@ -1,7 +1,6 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package imagedigest utility packages to abstract the retrieval of Digests
 package imagedigest
 
 import (

--- a/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/internal/util/level_logger.go
+++ b/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/internal/util/level_logger.go
@@ -1,7 +1,6 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package util contains internal utility tools used in imgpkg
 package util
 
 // LogLevel specifies logging level (i.e. DEBUG, WARN)

--- a/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/registry/auth/credentialprovider/keyring.go
+++ b/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/registry/auth/credentialprovider/keyring.go
@@ -1,7 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package credentialprovider contains helper functions used in auth package
 package credentialprovider
 
 import (

--- a/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/registry/auth/custom_keychain.go
+++ b/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/registry/auth/custom_keychain.go
@@ -1,7 +1,6 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package auth provides different keychains used in imgpkg
 package auth
 
 import (

--- a/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/signature/cosign.go
+++ b/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/signature/cosign.go
@@ -42,9 +42,6 @@ func (c Cosign) Signature(imageRef regname.Digest) (imageset.UnprocessedImageRef
 			if transportErr.StatusCode == http.StatusNotFound {
 				return imageset.UnprocessedImageRef{}, NotFoundErr{}
 			}
-			if transportErr.StatusCode == http.StatusForbidden {
-				return imageset.UnprocessedImageRef{}, AccessDeniedErr{imageRef: sigTagRef.Identifier()}
-			}
 		}
 		return imageset.UnprocessedImageRef{}, err
 	}

--- a/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/signature/fetch_signatures.go
+++ b/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/signature/fetch_signatures.go
@@ -19,64 +19,12 @@ type Finder interface {
 	Signature(reference name.Digest) (imageset.UnprocessedImageRef, error)
 }
 
-// FetchingError Error type that happen when fetching signatures
-type FetchingError interface {
-	error
-	ImageRef() string
-}
-
 // NotFoundErr specific not found error
-type NotFoundErr struct {
-	imageRef string
-}
-
-// ImageRef Image Reference and associated to the error
-func (n NotFoundErr) ImageRef() string {
-	return n.imageRef
-}
+type NotFoundErr struct{}
 
 // Error Not Found Error message
-func (n NotFoundErr) Error() string {
+func (s NotFoundErr) Error() string {
 	return "signature not found"
-}
-
-// AccessDeniedErr specific access denied error
-type AccessDeniedErr struct {
-	imageRef string
-}
-
-// ImageRef Image Reference and associated to the error
-func (a AccessDeniedErr) ImageRef() string {
-	return a.imageRef
-}
-
-// Error Access Denied message
-func (a AccessDeniedErr) Error() string {
-	return "access denied"
-}
-
-// FetchError Struct that will contain all the errors found while fetching signatures
-type FetchError struct {
-	AllErrors []FetchingError
-}
-
-// Error message that contains all errors
-func (f *FetchError) Error() string {
-	msg := "Unable to retrieve the following images:\n"
-	for _, err := range f.AllErrors {
-		msg = fmt.Sprintf("%sImage: '%s'\nError:%s", msg, err.ImageRef(), err.Error())
-	}
-	return msg
-}
-
-// HasErrors check if any error happened
-func (f *FetchError) HasErrors() bool {
-	return len(f.AllErrors) > 0
-}
-
-// Add a new error to the list of errors
-func (f *FetchError) Add(err FetchingError) {
-	f.AllErrors = append(f.AllErrors, err)
 }
 
 // Signatures Signature fetcher
@@ -123,7 +71,6 @@ func (s *Signatures) FetchForImageRefs(images []lockconfig.ImageRef) ([]lockconf
 
 	throttle := util.NewThrottle(s.concurrency)
 	var wg errgroup.Group
-	allErrs := &FetchError{}
 
 	for _, ref := range images {
 		ref := ref //copy
@@ -138,16 +85,10 @@ func (s *Signatures) FetchForImageRefs(images []lockconfig.ImageRef) ([]lockconf
 
 			signature, err := s.signatureFinder.Signature(imgDigest)
 			if err != nil {
-				if _, ok := err.(NotFoundErr); ok {
-					return nil
+				if _, ok := err.(NotFoundErr); !ok {
+					return fmt.Errorf("Fetching signature for image '%s': %s", imgDigest.Name(), err)
 				}
-				if deniedErr, ok := err.(AccessDeniedErr); ok {
-					lock.Lock()
-					defer lock.Unlock()
-					allErrs.Add(deniedErr)
-					return nil
-				}
-				return fmt.Errorf("Fetching signature for image '%s': %s", imgDigest.Name(), err)
+				return nil
 			}
 
 			lock.Lock()
@@ -162,15 +103,7 @@ func (s *Signatures) FetchForImageRefs(images []lockconfig.ImageRef) ([]lockconf
 
 	err := wg.Wait()
 
-	if err != nil {
-		return signatures, err
-	}
-
-	if allErrs.HasErrors() {
-		return signatures, allErrs
-	}
-
-	return signatures, nil
+	return signatures, err
 }
 
 // Noop No Operation signature fetcher

--- a/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/v1/describe.go
+++ b/vendor/github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/v1/describe.go
@@ -1,7 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package v1 contains the public API version 1 used by other tools to interact with imgpkg
 package v1
 
 import (
@@ -35,11 +34,10 @@ type Metadata struct {
 
 // ImageInfo URLs where the image can be found as well as annotations provided in the Images Lock
 type ImageInfo struct {
-	Image       string            `json:"image,omitempty"`
-	Origin      string            `json:"origin,omitempty"`
+	Image       string            `json:"image"`
+	Origin      string            `json:"origin"`
 	Annotations map[string]string `json:"annotations,omitempty"`
 	ImageType   bundle.ImageType  `json:"imageType"`
-	Error       string            `json:"error,omitempty"`
 }
 
 // Content Contents present in a Bundle
@@ -166,22 +164,15 @@ func (r *refWithDescription) describeBundleRec(visitedImgs map[string]refWithDes
 			}
 			desc.bundle.Content.Bundles[digest.DigestStr()] = bundleDesc
 		} else {
-			if ref.Error == "" {
-				digest, err := name.NewDigest(ref.Image)
-				if err != nil {
-					panic(fmt.Sprintf("Internal inconsistency: image %s should be fully resolved", ref.Image))
-				}
-				desc.bundle.Content.Images[digest.DigestStr()] = ImageInfo{
-					Image:       ref.PrimaryLocation(),
-					Origin:      ref.Image,
-					Annotations: ref.Annotations,
-					ImageType:   ref.ImageType,
-				}
-			} else {
-				desc.bundle.Content.Images[ref.Image] = ImageInfo{
-					ImageType: ref.ImageType,
-					Error:     ref.Error,
-				}
+			digest, err := name.NewDigest(ref.Image)
+			if err != nil {
+				panic(fmt.Sprintf("Internal inconsistency: image %s should be fully resolved", ref.Image))
+			}
+			desc.bundle.Content.Images[digest.DigestStr()] = ImageInfo{
+				Image:       ref.PrimaryLocation(),
+				Origin:      ref.Image,
+				Annotations: ref.Annotations,
+				ImageType:   ref.ImageType,
 			}
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -361,7 +361,7 @@ github.com/vbatts/tar-split/archive/tar
 # github.com/vito/go-interact v1.0.1
 ## explicit; go 1.12
 github.com/vito/go-interact/interact
-# github.com/vmware-tanzu/carvel-imgpkg v0.35.0
+# github.com/vmware-tanzu/carvel-imgpkg v0.33.1
 ## explicit; go 1.19
 github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/bundle
 github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/image


### PR DESCRIPTION
This PR was introduced because the bump on the minor 0.32.x of vendir is not supposed to introduce new features and imgpkg version 0.35.0 does have new features.

For this PR we should test that the keychains are being used correctly. This can be achieved by creating and image in a registry and trying to use vendir in a cluster from the same provider and see that the image is retrievable without a password being provided.