### PR TITLE
Bump go version to 1.20.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,6 +22,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.51.2
           args: -v
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,10 +12,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go 1.19.5
+      - name: Install Go 1.20.1
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.5"
+          go-version: "1.20.1"
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.5
+          go-version: 1.20.1
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5e15885530fb01d81d1f24e8a6f54ebbd0fed7eb
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v1
       with:
-        go-version: "1.19.5"
+        go-version: "1.20.1"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
       with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       repo: carvel-dev/vendir
       tool: vendir
-      goVersion: 1.19.5
+      goVersion: 1.20.1
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       slackWebhookURL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/cmd/vendir/vendir.go
+++ b/cmd/vendir/vendir.go
@@ -6,9 +6,7 @@ package main
 import (
 	"io"
 	"log"
-	"math/rand"
 	"os"
-	"time"
 
 	uierrs "github.com/cppforlife/go-cli-ui/errors"
 	"github.com/cppforlife/go-cli-ui/ui"
@@ -16,8 +14,6 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	log.SetOutput(io.Discard)
 
 	// TODO logs

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/carvel-vendir
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bmatcuk/doublestar v1.2.1


### PR DESCRIPTION
- Bump go version to 1.20.1
- Bump golangci-lint to 1.51.2 as go 1.20 support was added in 1.51.0
- Fixing golangci-lint error: rand.Seed has been deprecated since Go 1.20. 
            Seeding is added by default from 1.20 onwards. More info [here]( https://github.com/golang/go/blob/3f8f929d60a90c4e4e2b07c8d1972166c1a783b1/src/math/rand/rand.go#L383)