### PR TITLE
Bump golang 1.20.3 and golint changes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,16 +12,16 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go 1.19.6
+      - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.6"
+          go-version: "1.20.3"
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v3.4.0
         with:
-          version: v1.49.0
+          version: v1.52.2
           args: -v
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.6
+          go-version: 1.20.3
       - name: Retrieve version
         run: |
           echo "TAG_NAME=$(echo ${{ github.ref }}  | grep -Eo 'v[0-9].*')" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v1
       with:
-        go-version: "1.19.6"
+        go-version: "1.20.3"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
       with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       repo: carvel-dev/vendir
       tool: vendir
-      goVersion: 1.19.6
+      goVersion: 1.20.3
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       slackWebhookURL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/cmd/vendir/vendir.go
+++ b/cmd/vendir/vendir.go
@@ -16,7 +16,7 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UTC().UnixNano())
+	rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 
 	log.SetOutput(io.Discard)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/carvel-vendir
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bmatcuk/doublestar v1.2.1

--- a/pkg/vendir/directory/staging_dir.go
+++ b/pkg/vendir/directory/staging_dir.go
@@ -104,7 +104,7 @@ func (d StagingDir) CopyExistingFiles(rootDir string, stagingPath string, ignore
 		}
 
 		// Move the file to the staging directory
-		err = copy(path, stagingPath)
+		err = copyFile(path, stagingPath)
 		if err != nil {
 			return fmt.Errorf("Moving source file '%s' to staging location '%s': %s", path, stagingPath, err)
 		}
@@ -194,7 +194,7 @@ func (d StagingTempArea) NewTempFile(pattern string) (*os.File, error) {
 	return os.CreateTemp(d.path, pattern)
 }
 
-func copy(src, dst string) error {
+func copyFile(src, dst string) error {
 	sourceFileStat, err := os.Stat(src)
 	if err != nil {
 		return fmt.Errorf("Unable to read file info: %s", src)

--- a/pkg/vendir/fetch/ref_fetcher.go
+++ b/pkg/vendir/fetch/ref_fetcher.go
@@ -27,6 +27,6 @@ func (f SingleSecretRefFetcher) GetSecret(name string) (ctlconf.Secret, error) {
 	return ctlconf.Secret{}, fmt.Errorf("Not found")
 }
 
-func (f SingleSecretRefFetcher) GetConfigMap(name string) (ctlconf.ConfigMap, error) {
+func (f SingleSecretRefFetcher) GetConfigMap(_ string) (ctlconf.ConfigMap, error) {
 	return ctlconf.ConfigMap{}, fmt.Errorf("Not found")
 }


### PR DESCRIPTION
- Bump golang to 1.20.3 to fix CVE's in go 1.19.6