### PR TITLE
Refactor lazy sync code

### DIFF
--- a/pkg/vendir/cmd/sync.go
+++ b/pkg/vendir/cmd/sync.go
@@ -9,13 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/cppforlife/go-cli-ui/ui"
-	"github.com/mitchellh/go-homedir"
-	"github.com/spf13/cobra"
-
 	ctlconf "carvel.dev/vendir/pkg/vendir/config"
 	ctldir "carvel.dev/vendir/pkg/vendir/directory"
 	ctlcache "carvel.dev/vendir/pkg/vendir/fetch/cache"
+	"github.com/cppforlife/go-cli-ui/ui"
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
 )
 
 const (

--- a/pkg/vendir/config/directory.go
+++ b/pkg/vendir/config/directory.go
@@ -112,7 +112,7 @@ type DirectoryContentsImage struct {
 
 	// Secret may include one or more keys: username, password, token.
 	// By default anonymous access is used for authentication.
-	// TODO support docker config formated secret
+	// TODO support docker config formatted secret
 	// +optional
 	SecretRef *DirectoryContentsLocalRef `json:"secretRef,omitempty"`
 
@@ -130,7 +130,7 @@ type DirectoryContentsImgpkgBundle struct {
 
 	// Secret may include one or more keys: username, password, token.
 	// By default anonymous access is used for authentication.
-	// TODO support docker config formated secret
+	// TODO support docker config formatted secret
 	// +optional
 	SecretRef *DirectoryContentsLocalRef `json:"secretRef,omitempty"`
 

--- a/pkg/vendir/config/lock_config.go
+++ b/pkg/vendir/config/lock_config.go
@@ -28,16 +28,6 @@ func NewLockConfig() LockConfig {
 	}
 }
 
-func LockFileExists(path string) bool {
-	if _, err := os.Stat(path); err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return false
-		}
-		panic(fmt.Errorf("can not stat file '%v': %v", path, err))
-	}
-	return true
-}
-
 func NewLockConfigFromFile(path string) (LockConfig, error) {
 	bs, err := os.ReadFile(path)
 	if err != nil {
@@ -155,7 +145,6 @@ func (c *LockConfig) Merge(other LockConfig) error {
 }
 
 func (c *LockConfig) ReplaceContents(path string, replaceCon LockDirectoryContents) bool {
-
 	for i, dir := range c.Directories {
 		for j, con := range dir.Contents {
 			if filepath.Join(dir.Path, con.Path) != path {

--- a/pkg/vendir/directory/directory.go
+++ b/pkg/vendir/directory/directory.go
@@ -9,9 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/cppforlife/go-cli-ui/ui"
-	dircopy "github.com/otiai10/copy"
 	"sigs.k8s.io/yaml"
 
 	ctlconf "carvel.dev/vendir/pkg/vendir/config"
@@ -25,6 +22,8 @@ import (
 	ctlimg "carvel.dev/vendir/pkg/vendir/fetch/image"
 	ctlimgpkgbundle "carvel.dev/vendir/pkg/vendir/fetch/imgpkgbundle"
 	ctlinl "carvel.dev/vendir/pkg/vendir/fetch/inline"
+	"github.com/cppforlife/go-cli-ui/ui"
+	dircopy "github.com/otiai10/copy"
 )
 
 type Directory struct {

--- a/vendor/github.com/containerd/stargz-snapshotter/estargz/testutil.go
+++ b/vendor/github.com/containerd/stargz-snapshotter/estargz/testutil.go
@@ -379,7 +379,6 @@ func compressBlob(t *testing.T, src *io.SectionReader, srcCompression int) *io.S
 	}
 	data := buf.Bytes()
 	return io.NewSectionReader(bytes.NewReader(data), 0, int64(len(data)))
-
 }
 
 type stargzEntry struct {
@@ -409,7 +408,7 @@ func contains(t *testing.T, a, b stargzEntry) bool {
 				return true // Ignore landmarks
 			}
 
-			// Ignore a TOCEntry of "./" (formated as "" by stargz lib) on root directory
+			// Ignore a TOCEntry of "./" (formatted as "" by stargz lib) on root directory
 			// because this points to the root directory itself.
 			if aChild.Name == "" && ae.Name == "" {
 				return true
@@ -1948,7 +1947,6 @@ func lookupMatch(name string, want *TOCEntry) stargzCheck {
 		if !reflect.DeepEqual(e, want) {
 			t.Errorf("entry %q mismatch.\n got: %+v\nwant: %+v\n", name, e, want)
 		}
-
 	})
 }
 
@@ -2200,6 +2198,7 @@ func blockdev(name string, major, minor int64) tarEntry {
 		})
 	})
 }
+
 func fifo(name string) tarEntry {
 	now := time.Now()
 	return tarEntryFunc(func(w *tar.Writer, prefix string, format tar.Format) error {


### PR DESCRIPTION
This PR:

- simplifies lazy sync flags handling
- correctly handles os.Stat errors in some places
- removes not needed functions
- fixes spelling

For a reviewer: checking every commit separately may be easier, as the changes are grouped logically.
