### PR TITLE
fix: clean paths after reading config

### DIFF
--- a/pkg/vendir/config/config.go
+++ b/pkg/vendir/config/config.go
@@ -9,9 +9,10 @@ import (
 	"reflect"
 	"strings"
 
-	"carvel.dev/vendir/pkg/vendir/version"
 	semver "github.com/hashicorp/go-version"
 	"sigs.k8s.io/yaml"
+
+	"carvel.dev/vendir/pkg/vendir/version"
 )
 
 const (
@@ -69,6 +70,7 @@ func NewConfigFromFiles(paths []string) (Config, []Secret, []ConfigMap, error) {
 
 		case res.APIVersion == knownAPIVersion && res.Kind == knownKind:
 			config, err := NewConfigFromBytes(docBytes)
+			config.cleanPaths()
 			if err != nil {
 				return fmt.Errorf("Unmarshaling config: %s", err)
 			}
@@ -277,4 +279,13 @@ func (c Config) checkOverlappingPaths() error {
 	}
 
 	return nil
+}
+
+func (c *Config) cleanPaths() {
+	for i, dir := range c.Directories {
+		c.Directories[i].Path = filepath.Clean(dir.Path)
+		for j, con := range dir.Contents {
+			c.Directories[i].Contents[j].Path = filepath.Clean(con.Path)
+		}
+	}
 }

--- a/pkg/vendir/config/config.go
+++ b/pkg/vendir/config/config.go
@@ -9,10 +9,9 @@ import (
 	"reflect"
 	"strings"
 
+	"carvel.dev/vendir/pkg/vendir/version"
 	semver "github.com/hashicorp/go-version"
 	"sigs.k8s.io/yaml"
-
-	"carvel.dev/vendir/pkg/vendir/version"
 )
 
 const (


### PR DESCRIPTION
This PR adds mandatory processing of directory and content paths with the `filepath.Clean` function. It allows to avoid problems with paths containing `..` and `.`. This, in turn, fixes the lazy functionality. At the moment, paths `foo` and `foo/` (or even `foo//`) are treated as different destinations and are re-downloaded.

Fixes #347
Fixes #348
