### PR TITLE
updated release to have installation and verification steps included in release notes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,6 +69,63 @@ release:
   # Defaults to false.
   disable: false
 
+  header: |
+    <details>
+
+    <summary><h2>Installation and signature verification</h2></summary>
+
+    ### Installation
+    
+    #### By downloading binary from the release
+
+    For instance, if you are using Linux on an AMD64 architecture:
+    ```shell
+    # Download the binary
+    curl -LO https://github.com/{{ .Env.GITHUB_REPOSITORY }}/releases/download/{{ .Tag }}/{{ .ProjectName }}-linux-amd64
+
+    # Move the binary in to your PATH
+    mv vendir-linux-amd64 /usr/local/bin/vendir
+
+    # Make the binary executable
+    chmod +x /usr/local/bin/vendir
+    ```
+
+    #### Via Homebrew (macOS or Linux)
+    ```shell
+    $ brew tap carvel-dev/carvel
+    $ brew install vendir
+    $ vendir version  
+    ```
+
+    ### Verify checksums file signature
+
+    Install cosign on your system https://docs.sigstore.dev/system_config/installation/
+    
+    The checksums file provided within the artifacts attached to this release is signed using [Cosign](https://docs.sigstore.dev/cosign/overview/) with GitHub OIDC. To validate the signature of this file, run the following commands:
+
+    ```shell
+    # Download the checksums file, certificate and signature
+    curl -LO https://github.com/{{ .Env.GITHUB_REPOSITORY }}/releases/download/{{ .Tag }}/checksums.txt
+    curl -LO https://github.com/{{ .Env.GITHUB_REPOSITORY }}/releases/download/{{ .Tag }}/checksums.txt.pem
+    curl -LO https://github.com/{{ .Env.GITHUB_REPOSITORY }}/releases/download/{{ .Tag }}/checksums.txt.sig
+ 
+    # Verify the checksums file
+    cosign verify-blob checksums.txt \
+      --certificate checksums.txt.pem \
+      --signature checksums.txt.sig \
+      --certificate-identity-regexp=https://github.com/{{ .Env.GITHUB_REPOSITORY_OWNER }} \
+      --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+    ```
+
+    ### Verify binary integrity
+
+    To verify the integrity of the downloaded binary, you can utilize the checksums file after having validated its signature.
+    ```shell
+    # Verify the binary using the checksums file
+    sha256sum -c checksums.txt --ignore-missing
+    ```
+    </details>
+
 changelog:
   # Set it to true if you wish to skip the changelog generation.
   # This may result in an empty release notes on GitHub/GitLab/Gitea.


### PR DESCRIPTION
### **With this change release notes will look like:**


 # :sparkles: What's new
* Test PR by @kumaritanushree in https://github.com/kumaritanushree/vendir/pull/1

## New Contributors
* @kumaritanushree made their first contribution in https://github.com/kumaritanushree/vendir/pull/1

 <details>

<summary><h2>Installation and signature verification</h2></summary>

### Installation
    
#### By downloading binary from the release

For instance, if you are using Linux on an AMD64 architecture:
```shell
# Download the binary
curl -LO https://github.com/{{ .Env.GITHUB_REPOSITORY }}/releases/download/{{ .Tag }}/{{ .ProjectName }}-linux-amd64

# Move the binary in to your PATH
mv vendir-linux-amd64 /usr/local/bin/vendir

# Make the binary executable
chmod +x /usr/local/bin/vendir
```

#### Via Homebrew (macOS or Linux)
```shell
$ brew tap carvel-dev/carvel
$ brew install vendir
$ vendir version  
 ```

### Verify checksums file signature

Need to install cosign on your system https://docs.sigstore.dev/system_config/installation/

 The checksums file provided within the artifacts attached to this release is signed using [Cosign](https://docs.sigstore.dev/cosign/overview/) with GitHub OIDC. To validate the signature of this file, run the following commands:

```shell
# Download the checksums file, certificate and signature
curl -LO https://github.com/{{ .Env.GITHUB_REPOSITORY }}/releases/download/{{ .Tag }}/checksums.txt
curl -LO https://github.com/{{ .Env.GITHUB_REPOSITORY }}/releases/download/{{ .Tag }}/checksums.txt.pem
curl -LO https://github.com/{{ .Env.GITHUB_REPOSITORY }}/releases/download/{{ .Tag }}/checksums.txt.sig

# Verify the checksums file
cosign verify-blob checksums.txt \
--certificate checksums.txt.pem \
--signature checksums.txt.sig \
--certificate-identity-regexp=https://github.com/{{ .Env.GITHUB_REPOSITORY_OWNER }} \
--certificate-oidc-issuer=https://token.actions.githubusercontent.com
```

### Verify binary integrity

To verify the integrity of the downloaded binary, you can utilize the checksums file after having validated its signature.
```shell
# Verify the binary using the checksums file
sha256sum -c checksums.txt --ignore-missing
```
</details>

**Full Changelog**: https://github.com/kumaritanushree/vendir/compare/v0.0.28...v0.0.29

# :open_file_folder: Files Checksum

```
4bce0e1e2865610292f4230ad4f1f4edc69fa4062fc68b54e288656f4bc23f3e  ./vendir-linux-arm64
7470d4b9f80e40b6c474a77ffe4e9dd78770426fa3d3ca8e54daf0ccbde94ae0  ./vendir-darwin-arm64
a488635950e1581ea3a8985a13a49aebb369d5f7aa4bad0a2d229e0161f118a7  ./vendir-linux-amd64
c532c980ec2d4e8d6d7ee845abc4366ae1dacf8f663801e6ff730ab3b9e6b6ad  ./vendir-windows-amd64.exe
c74203afdfd05525054617cf2ff6401f3ea86eb9f2385acb2afe4e06089f31b8  ./vendir-darwin-amd64
```