### PR TITLE
[chore] bump docker/docker, docker/cli to v25.0.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,9 +60,9 @@ require (
 	github.com/cppforlife/color v1.9.1-0.20200716202919-6706ac40b835 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimchansky/utfbom v1.1.0 // indirect
-	github.com/docker/cli v24.0.0+incompatible // indirect
+	github.com/docker/cli v25.0.5+incompatible // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
-	github.com/docker/docker v24.0.9+incompatible // indirect
+	github.com/docker/docker v25.0.5+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/emicklei/go-restful v2.16.0+incompatible // indirect
 	github.com/fatih/color v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,12 +99,12 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TRo4=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
-github.com/docker/cli v24.0.0+incompatible h1:0+1VshNwBQzQAx9lOl+OYCTCEAD8fKs/qeXMx3O0wqM=
-github.com/docker/cli v24.0.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v25.0.5+incompatible h1:3Llw3kcE1gOScEojA247iDD+p1l9hHeC7H3vf3Zd5fk=
+github.com/docker/cli v25.0.5+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v24.0.9+incompatible h1:HPGzNmwfLZWdxHqK9/II92pyi1EpYKsAqcl4G0Of9v0=
-github.com/docker/docker v24.0.9+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v25.0.5+incompatible h1:UmQydMduGkrD5nQde1mecF/YnSbTOaPeFIeP5C4W+DE=
+github.com/docker/docker v25.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=

--- a/vendor/github.com/docker/cli/AUTHORS
+++ b/vendor/github.com/docker/cli/AUTHORS
@@ -2,6 +2,7 @@
 # This file lists all contributors to the repository.
 # See scripts/docs/generate-authors.sh to make modifications.
 
+A. Lester Buck III <github-reg@nbolt.com>
 Aanand Prasad <aanand.prasad@gmail.com>
 Aaron L. Xu <liker.xu@foxmail.com>
 Aaron Lehmann <alehmann@netflix.com>
@@ -16,6 +17,7 @@ Adolfo Ochagavía <aochagavia92@gmail.com>
 Adrian Plata <adrian.plata@docker.com>
 Adrien Duermael <adrien@duermael.com>
 Adrien Folie <folie.adrien@gmail.com>
+Adyanth Hosavalike <ahosavalike@ucsd.edu>
 Ahmet Alp Balkan <ahmetb@microsoft.com>
 Aidan Feldman <aidan.feldman@gmail.com>
 Aidan Hobson Sayers <aidanhs@cantab.net>
@@ -26,7 +28,7 @@ Akim Demaille <akim.demaille@docker.com>
 Alan Thompson <cloojure@gmail.com>
 Albert Callarisa <shark234@gmail.com>
 Alberto Roura <mail@albertoroura.com>
-Albin Kerouanton <albin@akerouanton.name>
+Albin Kerouanton <albinker@gmail.com>
 Aleksa Sarai <asarai@suse.de>
 Aleksander Piotrowski <apiotrowski312@gmail.com>
 Alessandro Boch <aboch@tetrationanalytics.com>
@@ -34,6 +36,7 @@ Alex Couture-Beil <alex@earthly.dev>
 Alex Mavrogiannis <alex.mavrogiannis@docker.com>
 Alex Mayer <amayer5125@gmail.com>
 Alexander Boyd <alex@opengroove.org>
+Alexander Chneerov <achneerov@gmail.com>
 Alexander Larsson <alexl@redhat.com>
 Alexander Morozov <lk4d4math@gmail.com>
 Alexander Ryabov <i@sepa.spb.ru>
@@ -41,6 +44,7 @@ Alexandre González <agonzalezro@gmail.com>
 Alexey Igrychev <alexey.igrychev@flant.com>
 Alexis Couvreur <alexiscouvreur.pro@gmail.com>
 Alfred Landrum <alfred.landrum@docker.com>
+Ali Rostami <rostami.ali@gmail.com>
 Alicia Lauerman <alicia@eta.im>
 Allen Sun <allensun.shl@alibaba-inc.com>
 Alvin Deng <alvin.q.deng@utexas.edu>
@@ -79,7 +83,9 @@ Arko Dasgupta <arko@tetrate.io>
 Arnaud Porterie <icecrime@gmail.com>
 Arnaud Rebillout <elboulangero@gmail.com>
 Arthur Peka <arthur.peka@outlook.com>
+Ashly Mathew <ashly.mathew@sap.com>
 Ashwini Oruganti <ashwini.oruganti@gmail.com>
+Aslam Ahemad <aslamahemad@gmail.com>
 Azat Khuyiyakhmetov <shadow_uz@mail.ru>
 Bardia Keyoumarsi <bkeyouma@ucsc.edu>
 Barnaby Gray <barnaby@pickle.me.uk>
@@ -98,7 +104,9 @@ Bill Wang <ozbillwang@gmail.com>
 Bin Liu <liubin0329@gmail.com>
 Bingshen Wang <bingshen.wbs@alibaba-inc.com>
 Bishal Das <bishalhnj127@gmail.com>
+Bjorn Neergaard <bjorn.neergaard@docker.com>
 Boaz Shuster <ripcurld.github@gmail.com>
+Boban Acimovic <boban.acimovic@gmail.com>
 Bogdan Anton <contact@bogdananton.ro>
 Boris Pruessmann <boris@pruessmann.org>
 Brad Baker <brad@brad.fi>
@@ -109,6 +117,7 @@ Brent Salisbury <brent.salisbury@docker.com>
 Bret Fisher <bret@bretfisher.com>
 Brian (bex) Exelbierd <bexelbie@redhat.com>
 Brian Goff <cpuguy83@gmail.com>
+Brian Tracy <brian.tracy33@gmail.com>
 Brian Wieder <brian@4wieders.com>
 Bruno Sousa <bruno.sousa@docker.com>
 Bryan Bess <squarejaw@bsbess.com>
@@ -136,6 +145,7 @@ Chen Chuanliang <chen.chuanliang@zte.com.cn>
 Chen Hanxiao <chenhanxiao@cn.fujitsu.com>
 Chen Mingjie <chenmingjie0828@163.com>
 Chen Qiu <cheney-90@hotmail.com>
+Chris Chinchilla <chris@chrischinchilla.com>
 Chris Couzens <ccouzens@gmail.com>
 Chris Gavin <chris@chrisgavin.me>
 Chris Gibson <chris@chrisg.io>
@@ -163,6 +173,8 @@ Conner Crosby <conner@cavcrosby.tech>
 Corey Farrell <git@cfware.com>
 Corey Quon <corey.quon@docker.com>
 Cory Bennet <cbennett@netflix.com>
+Cory Snider <csnider@mirantis.com>
+Craig Osterhout <craig.osterhout@docker.com>
 Craig Wilhite <crwilhit@microsoft.com>
 Cristian Staretu <cristian.staretu@gmail.com>
 Daehyeok Mun <daehyeok@gmail.com>
@@ -171,6 +183,7 @@ Daisuke Ito <itodaisuke00@gmail.com>
 dalanlan <dalanlan925@gmail.com>
 Damien Nadé <github@livna.org>
 Dan Cotora <dan@bluevision.ro>
+Danial Gharib <danial.mail.gh@gmail.com>
 Daniel Artine <daniel.artine@ufrj.br>
 Daniel Cassidy <mail@danielcassidy.me.uk>
 Daniel Dao <dqminh@cloudflare.com>
@@ -210,6 +223,7 @@ Denis Defreyne <denis@soundcloud.com>
 Denis Gladkikh <denis@gladkikh.email>
 Denis Ollier <larchunix@users.noreply.github.com>
 Dennis Docter <dennis@d23.nl>
+dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 Derek McGowan <derek@mcg.dev>
 Des Preston <despreston@gmail.com>
 Deshi Xiao <dxiao@redhat.com>
@@ -232,11 +246,13 @@ DongGeon Lee <secmatth1996@gmail.com>
 Doug Davis <dug@us.ibm.com>
 Drew Erny <derny@mirantis.com>
 Ed Costello <epc@epcostello.com>
+Ed Morley <501702+edmorley@users.noreply.github.com>
 Elango Sivanandam <elango.siva@docker.com>
 Eli Uriegas <eli.uriegas@docker.com>
 Eli Uriegas <seemethere101@gmail.com>
 Elias Faxö <elias.faxo@tre.se>
 Elliot Luo <956941328@qq.com>
+Eric Bode <eric.bode@foundries.io>
 Eric Curtin <ericcurtin17@gmail.com>
 Eric Engestrom <eric@engestrom.ch>
 Eric G. Noriega <enoriega@vizuri.com>
@@ -254,6 +270,7 @@ Eugene Yakubovich <eugene.yakubovich@coreos.com>
 Evan Allrich <evan@unguku.com>
 Evan Hazlett <ejhazlett@gmail.com>
 Evan Krall <krall@yelp.com>
+Evan Lezar <elezar@nvidia.com>
 Evelyn Xu <evelynhsu21@gmail.com>
 Everett Toews <everett.toews@rackspace.com>
 Fabio Falci <fabiofalci@gmail.com>
@@ -275,6 +292,7 @@ Frederik Nordahl Jul Sabroe <frederikns@gmail.com>
 Frieder Bluemle <frieder.bluemle@gmail.com>
 Gabriel Gore <gabgore@cisco.com>
 Gabriel Nicolas Avellaneda <avellaneda.gabriel@gmail.com>
+Gabriela Georgieva <gabriela.georgieva@docker.com>
 Gaetan de Villele <gdevillele@gmail.com>
 Gang Qiao <qiaohai8866@gmail.com>
 Gary Schaetz <gary@schaetzkc.com>
@@ -288,6 +306,7 @@ Gleb Stsenov <gleb.stsenov@gmail.com>
 Goksu Toprak <goksu.toprak@docker.com>
 Gou Rao <gou@portworx.com>
 Govind Rai <raigovind93@gmail.com>
+Graeme Wiebe <graeme.wiebe@gmail.com>
 Grant Reaber <grant.reaber@gmail.com>
 Greg Pflaum <gpflaum@users.noreply.github.com>
 Gsealy <jiaojingwei1001@hotmail.com>
@@ -311,6 +330,7 @@ Hernan Garcia <hernandanielg@gmail.com>
 Hongbin Lu <hongbin034@gmail.com>
 Hu Keping <hukeping@huawei.com>
 Huayi Zhang <irachex@gmail.com>
+Hugo Chastel <Hugo-C@users.noreply.github.com>
 Hugo Gabriel Eyherabide <hugogabriel.eyherabide@gmail.com>
 huqun <huqun@zju.edu.cn>
 Huu Nguyen <huu@prismskylabs.com>
@@ -329,9 +349,12 @@ Ivan Grund <ivan.grund@gmail.com>
 Ivan Markin <sw@nogoegst.net>
 Jacob Atzen <jacob@jacobatzen.dk>
 Jacob Tomlinson <jacob@tom.linson.uk>
+Jacopo Rigoli <rigoli.jacopo@gmail.com>
 Jaivish Kothari <janonymous.codevulture@gmail.com>
 Jake Lambert <jake.lambert@volusion.com>
 Jake Sanders <jsand@google.com>
+Jake Stokes <contactjake@developerjake.com>
+Jakub Panek <me@panekj.dev>
 James Nesbitt <james.nesbitt@wunderkraut.com>
 James Turnbull <james@lovedthanlost.net>
 Jamie Hannaford <jamie@limetree.org>
@@ -408,10 +431,12 @@ Josh Chorlton <jchorlton@gmail.com>
 Josh Hawn <josh.hawn@docker.com>
 Josh Horwitz <horwitz@addthis.com>
 Josh Soref <jsoref@gmail.com>
+Julian <gitea+julian@ic.thejulian.uk>
 Julien Barbier <write0@gmail.com>
 Julien Kassar <github@kassisol.com>
 Julien Maitrehenry <julien.maitrehenry@me.com>
 Justas Brazauskas <brazauskasjustas@gmail.com>
+Justin Chadwell <me@jedevc.com>
 Justin Cormack <justin.cormack@docker.com>
 Justin Simonelis <justin.p.simonelis@gmail.com>
 Justyn Temme <justyntemme@gmail.com>
@@ -434,7 +459,7 @@ Kelton Bassingthwaite <KeltonBassingthwaite@gmail.com>
 Ken Cochrane <kencochrane@gmail.com>
 Ken ICHIKAWA <ichikawa.ken@jp.fujitsu.com>
 Kenfe-Mickaël Laventure <mickael.laventure@gmail.com>
-Kevin Alvarez <crazy-max@users.noreply.github.com>
+Kevin Alvarez <github@crazymax.dev>
 Kevin Burke <kev@inburke.com>
 Kevin Feyrer <kevin.feyrer@btinternet.com>
 Kevin Kern <kaiwentan@harmonycloud.cn>
@@ -454,6 +479,7 @@ Kyle Mitofsky <Kylemit@gmail.com>
 Lachlan Cooper <lachlancooper@gmail.com>
 Lai Jiangshan <jiangshanlai@gmail.com>
 Lars Kellogg-Stedman <lars@redhat.com>
+Laura Brehm <laurabrehm@hey.com>
 Laura Frank <ljfrank@gmail.com>
 Laurent Erignoux <lerignoux@gmail.com>
 Lee Gaines <eightlimbed@gmail.com>
@@ -462,10 +488,10 @@ Lennie <github@consolejunkie.net>
 Leo Gallucci <elgalu3@gmail.com>
 Leonid Skorospelov <leosko94@gmail.com>
 Lewis Daly <lewisdaly@me.com>
+Li Fu Bang <lifubang@acmcoder.com>
 Li Yi <denverdino@gmail.com>
 Li Yi <weiyuan.yl@alibaba-inc.com>
 Liang-Chi Hsieh <viirya@gmail.com>
-Lifubang <lifubang@acmcoder.com>
 Lihua Tang <lhtang@alauda.io>
 Lily Guo <lily.guo@docker.com>
 Lin Lu <doraalin@163.com>
@@ -480,6 +506,7 @@ Louis Opter <kalessin@kalessin.fr>
 Luca Favatella <luca.favatella@erlang-solutions.com>
 Luca Marturana <lucamarturana@gmail.com>
 Lucas Chan <lucas-github@lucaschan.com>
+Luis Henrique Mulinari <luis.mulinari@gmail.com>
 Luka Hartwig <mail@lukahartwig.de>
 Lukas Heeren <lukas-heeren@hotmail.com>
 Lukasz Zajaczkowski <Lukasz.Zajaczkowski@ts.fujitsu.com>
@@ -498,6 +525,7 @@ mapk0y <mapk0y@gmail.com>
 Marc Bihlmaier <marc.bihlmaier@reddoxx.com>
 Marc Cornellà <hello@mcornella.com>
 Marco Mariani <marco.mariani@alterway.fr>
+Marco Spiess <marco.spiess@hotmail.de>
 Marco Vedovati <mvedovati@suse.com>
 Marcus Martins <marcus@docker.com>
 Marianna Tessel <mtesselh@gmail.com>
@@ -522,6 +550,7 @@ Max Shytikov <mshytikov@gmail.com>
 Maxime Petazzoni <max@signalfuse.com>
 Maximillian Fan Xavier <maximillianfx@gmail.com>
 Mei ChunTao <mei.chuntao@zte.com.cn>
+Melroy van den Berg <melroy@melroy.org>
 Metal <2466052+tedhexaflow@users.noreply.github.com>
 Micah Zoltu <micah@newrelic.com>
 Michael A. Smith <michael@smith-li.com>
@@ -593,6 +622,7 @@ Nishant Totla <nishanttotla@gmail.com>
 NIWA Hideyuki <niwa.niwa@nifty.ne.jp>
 Noah Treuhaft <noah.treuhaft@docker.com>
 O.S. Tezer <ostezer@gmail.com>
+Oded Arbel <oded@geek.co.il>
 Odin Ugedal <odin@ugedal.com>
 ohmystack <jun.jiang02@ele.me>
 OKA Naoya <git@okanaoya.com>
@@ -604,19 +634,21 @@ Otto Kekäläinen <otto@seravo.fi>
 Ovidio Mallo <ovidio.mallo@gmail.com>
 Pascal Borreli <pascal@borreli.com>
 Patrick Böänziger <patrick.baenziger@bsi-software.com>
+Patrick Daigle <114765035+pdaig@users.noreply.github.com>
 Patrick Hemmer <patrick.hemmer@gmail.com>
 Patrick Lang <plang@microsoft.com>
 Paul <paul9869@gmail.com>
 Paul Kehrer <paul.l.kehrer@gmail.com>
 Paul Lietar <paul@lietar.net>
 Paul Mulders <justinkb@gmail.com>
+Paul Seyfert <pseyfert.mathphys@gmail.com>
 Paul Weaver <pauweave@cisco.com>
 Pavel Pospisil <pospispa@gmail.com>
 Paweł Gronowski <pawel.gronowski@docker.com>
 Paweł Pokrywka <pepawel@users.noreply.github.com>
 Paweł Szczekutowicz <pszczekutowicz@gmail.com>
 Peeyush Gupta <gpeeyush@linux.vnet.ibm.com>
-Per Lundberg <per.lundberg@ecraft.com>
+Per Lundberg <perlun@gmail.com>
 Peter Dave Hello <hsu@peterdavehello.org>
 Peter Edge <peter.edge@gmail.com>
 Peter Hsu <shhsu@microsoft.com>
@@ -639,6 +671,7 @@ Preston Cowley <preston.cowley@sony.com>
 Pure White <daniel48@126.com>
 Qiang Huang <h.huangqiang@huawei.com>
 Qinglan Peng <qinglanpeng@zju.edu.cn>
+QQ喵 <gqqnb2005@gmail.com>
 qudongfang <qudongfang@gmail.com>
 Raghavendra K T <raghavendra.kt@linux.vnet.ibm.com>
 Rahul Kadyan <hi@znck.me>
@@ -657,6 +690,7 @@ Rick Wieman <git@rickw.nl>
 Ritesh H Shukla <sritesh@vmware.com>
 Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
 Rob Gulewich <rgulewich@netflix.com>
+Rob Murray <rob.murray@docker.com>
 Robert Wallis <smilingrob@gmail.com>
 Robin Naundorf <r.naundorf@fh-muenster.de>
 Robin Speekenbrink <robin@kingsquare.nl>
@@ -689,6 +723,7 @@ Sandro Jäckel <sandro.jaeckel@gmail.com>
 Santhosh Manohar <santhosh@docker.com>
 Sargun Dhillon <sargun@netflix.com>
 Saswat Bhattacharya <sas.saswat@gmail.com>
+Saurabh Kumar <saurabhkumar0184@gmail.com>
 Scott Brenner <scott@scottbrenner.me>
 Scott Collier <emailscottcollier@gmail.com>
 Sean Christopherson <sean.j.christopherson@intel.com>
@@ -788,6 +823,7 @@ uhayate <uhayate.gong@daocloud.io>
 Ulrich Bareth <ulrich.bareth@gmail.com>
 Ulysses Souza <ulysses.souza@docker.com>
 Umesh Yadav <umesh4257@gmail.com>
+Vaclav Struhar <struharv@gmail.com>
 Valentin Lorentz <progval+git@progval.net>
 Vardan Pogosian <vardan.pogosyan@gmail.com>
 Venkateswara Reddy Bukkasamudram <bukkasamudram@outlook.com>
@@ -795,6 +831,7 @@ Veres Lajos <vlajos@gmail.com>
 Victor Vieux <victor.vieux@docker.com>
 Victoria Bialas <victoria.bialas@docker.com>
 Viktor Stanchev <me@viktorstanchev.com>
+Ville Skyttä <ville.skytta@iki.fi>
 Vimal Raghubir <vraghubir0418@gmail.com>
 Vincent Batts <vbatts@redhat.com>
 Vincent Bernat <Vincent.Bernat@exoscale.ch>
@@ -831,6 +868,7 @@ Yong Tang <yong.tang.github@outlook.com>
 Yosef Fertel <yfertel@gmail.com>
 Yu Peng <yu.peng36@zte.com.cn>
 Yuan Sun <sunyuan3@huawei.com>
+Yucheng Wu <wyc123wyc@gmail.com>
 Yue Zhang <zy675793960@yeah.net>
 Yunxiang Huang <hyxqshk@vip.qq.com>
 Zachary Romero <zacromero3@gmail.com>

--- a/vendor/github.com/docker/cli/cli/config/config.go
+++ b/vendor/github.com/docker/cli/cli/config/config.go
@@ -16,31 +16,24 @@ import (
 )
 
 const (
-	// ConfigFileName is the name of config file
+	// EnvOverrideConfigDir is the name of the environment variable that can be
+	// used to override the location of the client configuration files (~/.docker).
+	//
+	// It takes priority over the default, but can be overridden by the "--config"
+	// command line option.
+	EnvOverrideConfigDir = "DOCKER_CONFIG"
+
+	// ConfigFileName is the name of the client configuration file inside the
+	// config-directory.
 	ConfigFileName = "config.json"
 	configFileDir  = ".docker"
-	oldConfigfile  = ".dockercfg" // Deprecated: remove once we stop printing deprecation warning
 	contextsDir    = "contexts"
 )
 
 var (
 	initConfigDir = new(sync.Once)
 	configDir     string
-	homeDir       string
 )
-
-// resetHomeDir is used in testing to reset the "homeDir" package variable to
-// force re-lookup of the home directory between tests.
-func resetHomeDir() {
-	homeDir = ""
-}
-
-func getHomeDir() string {
-	if homeDir == "" {
-		homeDir = homedir.Get()
-	}
-	return homeDir
-}
 
 // resetConfigDir is used in testing to reset the "configDir" package variable
 // and its sync.Once to force re-lookup between tests.
@@ -49,19 +42,14 @@ func resetConfigDir() {
 	initConfigDir = new(sync.Once)
 }
 
-func setConfigDir() {
-	if configDir != "" {
-		return
-	}
-	configDir = os.Getenv("DOCKER_CONFIG")
-	if configDir == "" {
-		configDir = filepath.Join(getHomeDir(), configFileDir)
-	}
-}
-
 // Dir returns the directory the configuration file is stored in
 func Dir() string {
-	initConfigDir.Do(setConfigDir)
+	initConfigDir.Do(func() {
+		configDir = os.Getenv(EnvOverrideConfigDir)
+		if configDir == "" {
+			configDir = filepath.Join(homedir.Get(), configFileDir)
+		}
+	})
 	return configDir
 }
 
@@ -72,6 +60,8 @@ func ContextStoreDir() string {
 
 // SetDir sets the directory the configuration file is stored in
 func SetDir(dir string) {
+	// trigger the sync.Once to synchronise with Dir()
+	initConfigDir.Do(func() {})
 	configDir = filepath.Clean(dir)
 }
 
@@ -96,55 +86,43 @@ func LoadFromReader(configData io.Reader) (*configfile.ConfigFile, error) {
 
 // Load reads the configuration files in the given directory, and sets up
 // the auth config information and returns values.
-// FIXME: use the internal golang config parser
 func Load(configDir string) (*configfile.ConfigFile, error) {
-	cfg, _, err := load(configDir)
-	return cfg, err
-}
-
-// TODO remove this temporary hack, which is used to warn about the deprecated ~/.dockercfg file
-// so we can remove the bool return value and collapse this back into `Load`
-func load(configDir string) (*configfile.ConfigFile, bool, error) {
-	printLegacyFileWarning := false
-
 	if configDir == "" {
 		configDir = Dir()
 	}
+	return load(configDir)
+}
 
+func load(configDir string) (*configfile.ConfigFile, error) {
 	filename := filepath.Join(configDir, ConfigFileName)
 	configFile := configfile.New(filename)
 
-	// Try happy path first - latest config file
-	if file, err := os.Open(filename); err == nil {
-		defer file.Close()
-		err = configFile.LoadFromReader(file)
-		if err != nil {
-			err = errors.Wrap(err, filename)
+	file, err := os.Open(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			//
+			// if file is there but we can't stat it for any reason other
+			// than it doesn't exist then stop
+			return configFile, nil
 		}
-		return configFile, printLegacyFileWarning, err
-	} else if !os.IsNotExist(err) {
 		// if file is there but we can't stat it for any reason other
 		// than it doesn't exist then stop
-		return configFile, printLegacyFileWarning, errors.Wrap(err, filename)
+		return configFile, nil
 	}
-
-	// Can't find latest config file so check for the old one
-	filename = filepath.Join(getHomeDir(), oldConfigfile)
-	if _, err := os.Stat(filename); err == nil {
-		printLegacyFileWarning = true
+	defer file.Close()
+	err = configFile.LoadFromReader(file)
+	if err != nil {
+		err = errors.Wrap(err, filename)
 	}
-	return configFile, printLegacyFileWarning, nil
+	return configFile, err
 }
 
 // LoadDefaultConfigFile attempts to load the default config file and returns
 // an initialized ConfigFile struct if none is found.
 func LoadDefaultConfigFile(stderr io.Writer) *configfile.ConfigFile {
-	configFile, printLegacyFileWarning, err := load(Dir())
+	configFile, err := load(Dir())
 	if err != nil {
-		fmt.Fprintf(stderr, "WARNING: Error loading config file: %v\n", err)
-	}
-	if printLegacyFileWarning {
-		_, _ = fmt.Fprintln(stderr, "WARNING: Support for the legacy ~/.dockercfg configuration file and file-format has been removed and the configuration file will be ignored")
+		_, _ = fmt.Fprintf(stderr, "WARNING: Error loading config file: %v\n", err)
 	}
 	if !configFile.ContainsAuth() {
 		configFile.CredentialsStore = credentials.DetectDefaultStore(configFile.CredentialsStore)

--- a/vendor/github.com/docker/cli/cli/config/configfile/file.go
+++ b/vendor/github.com/docker/cli/cli/config/configfile/file.go
@@ -94,6 +94,9 @@ func (configFile *ConfigFile) ContainsAuth() bool {
 
 // GetAuthConfigs returns the mapping of repo to auth configuration
 func (configFile *ConfigFile) GetAuthConfigs() map[string]types.AuthConfig {
+	if configFile.AuthConfigs == nil {
+		configFile.AuthConfigs = make(map[string]types.AuthConfig)
+	}
 	return configFile.AuthConfigs
 }
 

--- a/vendor/github.com/docker/cli/cli/config/configfile/file_unix.go
+++ b/vendor/github.com/docker/cli/cli/config/configfile/file_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package configfile
 

--- a/vendor/github.com/docker/cli/cli/config/credentials/default_store.go
+++ b/vendor/github.com/docker/cli/cli/config/credentials/default_store.go
@@ -1,21 +1,22 @@
 package credentials
 
-import (
-	exec "golang.org/x/sys/execabs"
-)
+import "os/exec"
 
 // DetectDefaultStore return the default credentials store for the platform if
-// the store executable is available.
+// no user-defined store is passed, and the store executable is available.
 func DetectDefaultStore(store string) string {
-	platformDefault := defaultCredentialsStore()
-
-	// user defined or no default for platform
-	if store != "" || platformDefault == "" {
+	if store != "" {
+		// use user-defined
 		return store
 	}
 
-	if _, err := exec.LookPath(remoteCredentialsPrefix + platformDefault); err == nil {
-		return platformDefault
+	platformDefault := defaultCredentialsStore()
+	if platformDefault == "" {
+		return ""
 	}
-	return ""
+
+	if _, err := exec.LookPath(remoteCredentialsPrefix + platformDefault); err != nil {
+		return ""
+	}
+	return platformDefault
 }

--- a/vendor/github.com/docker/cli/cli/config/credentials/default_store_unsupported.go
+++ b/vendor/github.com/docker/cli/cli/config/credentials/default_store_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !windows && !darwin && !linux
-// +build !windows,!darwin,!linux
 
 package credentials
 

--- a/vendor/github.com/docker/cli/cli/config/credentials/file_store.go
+++ b/vendor/github.com/docker/cli/cli/config/credentials/file_store.go
@@ -52,7 +52,8 @@ func (c *fileStore) GetAll() (map[string]types.AuthConfig, error) {
 
 // Store saves the given credentials in the file store.
 func (c *fileStore) Store(authConfig types.AuthConfig) error {
-	c.file.GetAuthConfigs()[authConfig.ServerAddress] = authConfig
+	authConfigs := c.file.GetAuthConfigs()
+	authConfigs[authConfig.ServerAddress] = authConfig
 	return c.file.Save()
 }
 

--- a/vendor/github.com/docker/cli/cli/config/credentials/native_store.go
+++ b/vendor/github.com/docker/cli/cli/config/credentials/native_store.go
@@ -51,6 +51,7 @@ func (c *nativeStore) Get(serverAddress string) (types.AuthConfig, error) {
 	auth.Username = creds.Username
 	auth.IdentityToken = creds.IdentityToken
 	auth.Password = creds.Password
+	auth.ServerAddress = creds.ServerAddress
 
 	return auth, nil
 }
@@ -76,6 +77,9 @@ func (c *nativeStore) GetAll() (map[string]types.AuthConfig, error) {
 		ac.Username = creds.Username
 		ac.Password = creds.Password
 		ac.IdentityToken = creds.IdentityToken
+		if ac.ServerAddress == "" {
+			ac.ServerAddress = creds.ServerAddress
+		}
 		authConfigs[registry] = ac
 	}
 

--- a/vendor/github.com/docker/docker/AUTHORS
+++ b/vendor/github.com/docker/docker/AUTHORS
@@ -27,6 +27,7 @@ Adam Miller <admiller@redhat.com>
 Adam Mills <adam@armills.info>
 Adam Pointer <adam.pointer@skybettingandgaming.com>
 Adam Singer <financeCoding@gmail.com>
+Adam Thornton <adam.thornton@maryville.com>
 Adam Walz <adam@adamwalz.net>
 Adam Williams <awilliams@mirantis.com>
 AdamKorcz <adam@adalogics.com>
@@ -173,6 +174,7 @@ Andy Rothfusz <github@developersupport.net>
 Andy Smith <github@anarkystic.com>
 Andy Wilson <wilson.andrew.j+github@gmail.com>
 Andy Zhang <andy.zhangtao@hotmail.com>
+Aneesh Kulkarni <askthefactorcamera@gmail.com>
 Anes Hasicic <anes.hasicic@gmail.com>
 Angel Velazquez <angelcar@amazon.com>
 Anil Belur <askb23@gmail.com>
@@ -236,6 +238,7 @@ Ben Golub <ben.golub@dotcloud.com>
 Ben Gould <ben@bengould.co.uk>
 Ben Hall <ben@benhall.me.uk>
 Ben Langfeld <ben@langfeld.me>
+Ben Lovy <ben@deciduously.com>
 Ben Sargent <ben@brokendigits.com>
 Ben Severson <BenSeverson@users.noreply.github.com>
 Ben Toews <mastahyeti@gmail.com>
@@ -262,7 +265,7 @@ Billy Ridgway <wrridgwa@us.ibm.com>
 Bily Zhang <xcoder@tenxcloud.com>
 Bin Liu <liubin0329@gmail.com>
 Bingshen Wang <bingshen.wbs@alibaba-inc.com>
-Bjorn Neergaard <bneergaard@mirantis.com>
+Bjorn Neergaard <bjorn@neersighted.com>
 Blake Geno <blakegeno@gmail.com>
 Boaz Shuster <ripcurld.github@gmail.com>
 bobby abbott <ttobbaybbob@gmail.com>
@@ -279,6 +282,7 @@ Brandon Liu <bdon@bdon.org>
 Brandon Philips <brandon.philips@coreos.com>
 Brandon Rhodes <brandon@rhodesmill.org>
 Brendan Dixon <brendand@microsoft.com>
+Brennan Kinney <5098581+polarathene@users.noreply.github.com>
 Brent Salisbury <brent.salisbury@docker.com>
 Brett Higgins <brhiggins@arbor.net>
 Brett Kochendorfer <brett.kochendorfer@gmail.com>
@@ -363,6 +367,7 @@ chenyuzhu <chenyuzhi@oschina.cn>
 Chetan Birajdar <birajdar.chetan@gmail.com>
 Chewey <prosto-chewey@users.noreply.github.com>
 Chia-liang Kao <clkao@clkao.org>
+Chiranjeevi Tirunagari <vchiranjeeviak.tirunagari@gmail.com>
 chli <chli@freewheel.tv>
 Cholerae Hu <choleraehyq@gmail.com>
 Chris Alfonso <calfonso@redhat.com>
@@ -433,8 +438,8 @@ Cristian Staretu <cristian.staretu@gmail.com>
 cristiano balducci <cristiano.balducci@gmail.com>
 Cristina Yenyxe Gonzalez Garcia <cristina.yenyxe@gmail.com>
 Cruceru Calin-Cristian <crucerucalincristian@gmail.com>
+cui fliter <imcusg@gmail.com>
 CUI Wei <ghostplant@qq.com>
-cuishuang <imcusg@gmail.com>
 Cuong Manh Le <cuong.manhle.vn@gmail.com>
 Cyprian Gracz <cyprian.gracz@micro-jumbo.eu>
 Cyril F <cyrilf7x@gmail.com>
@@ -513,6 +518,7 @@ David Dooling <dooling@gmail.com>
 David Gageot <david@gageot.net>
 David Gebler <davidgebler@gmail.com>
 David Glasser <glasser@davidglasser.net>
+David Karlsson <35727626+dvdksn@users.noreply.github.com>
 David Lawrence <david.lawrence@docker.com>
 David Lechner <david@lechnology.com>
 David M. Karr <davidmichaelkarr@gmail.com>
@@ -602,6 +608,7 @@ Donald Huang <don.hcd@gmail.com>
 Dong Chen <dongluo.chen@docker.com>
 Donghwa Kim <shanytt@gmail.com>
 Donovan Jones <git@gamma.net.nz>
+Dorin Geman <dorin.geman@docker.com>
 Doron Podoleanu <doronp@il.ibm.com>
 Doug Davis <dug@us.ibm.com>
 Doug MacEachern <dougm@vmware.com>
@@ -636,6 +643,7 @@ Emily Rose <emily@contactvibe.com>
 Emir Ozer <emirozer@yandex.com>
 Eng Zer Jun <engzerjun@gmail.com>
 Enguerran <engcolson@gmail.com>
+Enrico Weigelt, metux IT consult <info@metux.net>
 Eohyung Lee <liquidnuker@gmail.com>
 epeterso <epeterson@breakpoint-labs.com>
 er0k <er0k@er0k.net>
@@ -676,6 +684,7 @@ Evan Allrich <evan@unguku.com>
 Evan Carmi <carmi@users.noreply.github.com>
 Evan Hazlett <ejhazlett@gmail.com>
 Evan Krall <krall@yelp.com>
+Evan Lezar <elezar@nvidia.com>
 Evan Phoenix <evan@fallingsnow.net>
 Evan Wies <evan@neomantra.net>
 Evelyn Xu <evelynhsu21@gmail.com>
@@ -744,6 +753,7 @@ Frank Groeneveld <frank@ivaldi.nl>
 Frank Herrmann <fgh@4gh.tv>
 Frank Macreery <frank@macreery.com>
 Frank Rosquin <frank.rosquin+github@gmail.com>
+Frank Villaro-Dixon <frank.villarodixon@merkle.com>
 Frank Yang <yyb196@gmail.com>
 Fred Lifton <fred.lifton@docker.com>
 Frederick F. Kautz IV <fkautz@redhat.com>
@@ -983,6 +993,7 @@ Jean Rouge <rougej+github@gmail.com>
 Jean-Baptiste Barth <jeanbaptiste.barth@gmail.com>
 Jean-Baptiste Dalido <jeanbaptiste@appgratis.com>
 Jean-Christophe Berthon <huygens@berthon.eu>
+Jean-Michel Rouet <jm.rouet@gmail.com>
 Jean-Paul Calderone <exarkun@twistedmatrix.com>
 Jean-Pierre Huynh <jean-pierre.huynh@ounet.fr>
 Jean-Tiare Le Bigot <jt@yadutaf.fr>
@@ -1013,6 +1024,7 @@ Jeroen Jacobs <github@jeroenj.be>
 Jesse Dearing <jesse.dearing@gmail.com>
 Jesse Dubay <jesse@thefortytwo.net>
 Jessica Frazelle <jess@oxide.computer>
+Jeyanthinath Muthuram <jeyanthinath10@gmail.com>
 Jezeniel Zapanta <jpzapanta22@gmail.com>
 Jhon Honce <jhonce@redhat.com>
 Ji.Zhilong <zhilongji@gmail.com>
@@ -1141,6 +1153,7 @@ junxu <xujun@cmss.chinamobile.com>
 Jussi Nummelin <jussi.nummelin@gmail.com>
 Justas Brazauskas <brazauskasjustas@gmail.com>
 Justen Martin <jmart@the-coder.com>
+Justin Chadwell <me@jedevc.com>
 Justin Cormack <justin.cormack@docker.com>
 Justin Force <justin.force@gmail.com>
 Justin Keller <85903732+jk-vb@users.noreply.github.com>
@@ -1183,6 +1196,7 @@ Ke Xu <leonhartx.k@gmail.com>
 Kei Ohmura <ohmura.kei@gmail.com>
 Keith Hudgins <greenman@greenman.org>
 Keli Hu <dev@keli.hu>
+Ken Bannister <kb2ma@runbox.com>
 Ken Cochrane <kencochrane@gmail.com>
 Ken Herner <kherner@progress.com>
 Ken ICHIKAWA <ichikawa.ken@jp.fujitsu.com>
@@ -1192,7 +1206,7 @@ Kenjiro Nakayama <nakayamakenjiro@gmail.com>
 Kent Johnson <kentoj@gmail.com>
 Kenta Tada <Kenta.Tada@sony.com>
 Kevin "qwazerty" Houdebert <kevin.houdebert@gmail.com>
-Kevin Alvarez <crazy-max@users.noreply.github.com>
+Kevin Alvarez <github@crazymax.dev>
 Kevin Burke <kev@inburke.com>
 Kevin Clark <kevin.clark@gmail.com>
 Kevin Feyrer <kevin.feyrer@btinternet.com>
@@ -1225,6 +1239,7 @@ Konstantin Gribov <grossws@gmail.com>
 Konstantin L <sw.double@gmail.com>
 Konstantin Pelykh <kpelykh@zettaset.com>
 Kostadin Plachkov <k.n.plachkov@gmail.com>
+kpcyrd <git@rxv.cc>
 Krasi Georgiev <krasi@vip-consult.solutions>
 Krasimir Georgiev <support@vip-consult.co.uk>
 Kris-Mikael Krister <krismikael@protonmail.com>
@@ -1306,6 +1321,7 @@ Lorenzo Fontana <fontanalorenz@gmail.com>
 Lotus Fenn <fenn.lotus@gmail.com>
 Louis Delossantos <ldelossa.ld@gmail.com>
 Louis Opter <kalessin@kalessin.fr>
+Luboslav Pivarc <lpivarc@redhat.com>
 Luca Favatella <luca.favatella@erlang-solutions.com>
 Luca Marturana <lucamarturana@gmail.com>
 Luca Orlandi <luca.orlandi@gmail.com>
@@ -1344,6 +1360,7 @@ Manuel Meurer <manuel@krautcomputing.com>
 Manuel Rüger <manuel@rueg.eu>
 Manuel Woelker <github@manuel.woelker.org>
 mapk0y <mapk0y@gmail.com>
+Marat Radchenko <marat@slonopotamus.org>
 Marc Abramowitz <marc@marc-abramowitz.com>
 Marc Kuo <kuomarc2@gmail.com>
 Marc Tamsky <mtamsky@gmail.com>
@@ -1383,6 +1400,7 @@ Martijn van Oosterhout <kleptog@svana.org>
 Martin Braun <braun@neuroforge.de>
 Martin Dojcak <martin.dojcak@lablabs.io>
 Martin Honermeyer <maze@strahlungsfrei.de>
+Martin Jirku <martin@jirku.sk>
 Martin Kelly <martin@surround.io>
 Martin Mosegaard Amdisen <martin.amdisen@praqma.com>
 Martin Muzatko <martin@happy-css.com>
@@ -1461,6 +1479,7 @@ Michael Holzheu <holzheu@linux.vnet.ibm.com>
 Michael Hudson-Doyle <michael.hudson@canonical.com>
 Michael Huettermann <michael@huettermann.net>
 Michael Irwin <mikesir87@gmail.com>
+Michael Kebe <michael.kebe@hkm.de>
 Michael Kuehn <micha@kuehn.io>
 Michael Käufl <docker@c.michael-kaeufl.de>
 Michael Neale <michael.neale@gmail.com>
@@ -1509,10 +1528,11 @@ Mike Lundy <mike@fluffypenguin.org>
 Mike MacCana <mike.maccana@gmail.com>
 Mike Naberezny <mike@naberezny.com>
 Mike Snitzer <snitzer@redhat.com>
+Mike Sul <mike.sul@foundries.io>
 mikelinjie <294893458@qq.com>
 Mikhail Sobolev <mss@mawhrin.net>
 Miklos Szegedi <miklos.szegedi@cloudera.com>
-Milas Bowman <milasb@gmail.com>
+Milas Bowman <devnull@milas.dev>
 Milind Chawre <milindchawre@gmail.com>
 Miloslav Trmač <mitr@redhat.com>
 mingqing <limingqing@cyou-inc.com>
@@ -1524,6 +1544,7 @@ mlarcher <github@ringabell.org>
 Mohammad Banikazemi <MBanikazemi@gmail.com>
 Mohammad Nasirifar <farnasirim@gmail.com>
 Mohammed Aaqib Ansari <maaquib@gmail.com>
+Mohd Sadiq <mohdsadiq058@gmail.com>
 Mohit Soni <mosoni@ebay.com>
 Moorthy RS <rsmoorthy@gmail.com>
 Morgan Bauer <mbauer@us.ibm.com>
@@ -1606,6 +1627,7 @@ Noah Treuhaft <noah.treuhaft@docker.com>
 NobodyOnSE <ich@sektor.selfip.com>
 noducks <onemannoducks@gmail.com>
 Nolan Darilek <nolan@thewordnerd.info>
+Nolan Miles <nolanpmiles@gmail.com>
 Noriki Nakamura <noriki.nakamura@miraclelinux.com>
 nponeccop <andy.melnikov@gmail.com>
 Nurahmadie <nurahmadie@gmail.com>
@@ -1661,6 +1683,7 @@ Paul Lietar <paul@lietar.net>
 Paul Liljenberg <liljenberg.paul@gmail.com>
 Paul Morie <pmorie@gmail.com>
 Paul Nasrat <pnasrat@gmail.com>
+Paul Seiffert <paul.seiffert@jimdo.com>
 Paul Weaver <pauweave@cisco.com>
 Paulo Gomes <pjbgf@linux.com>
 Paulo Ribeiro <paigr.io@gmail.com>
@@ -1674,6 +1697,7 @@ Pavlos Ratis <dastergon@gentoo.org>
 Pavol Vargovcik <pallly.vargovcik@gmail.com>
 Pawel Konczalski <mail@konczalski.de>
 Paweł Gronowski <pawel.gronowski@docker.com>
+payall4u <payall4u@qq.com>
 Peeyush Gupta <gpeeyush@linux.vnet.ibm.com>
 Peggy Li <peggyli.224@gmail.com>
 Pei Su <sillyousu@gmail.com>
@@ -1703,7 +1727,9 @@ Phil Estes <estesp@gmail.com>
 Phil Sphicas <phil.sphicas@att.com>
 Phil Spitler <pspitler@gmail.com>
 Philip Alexander Etling <paetling@gmail.com>
+Philip K. Warren <pkwarren@gmail.com>
 Philip Monroe <phil@philmonroe.com>
+Philipp Fruck <dev@p-fruck.de>
 Philipp Gillé <philipp.gille@gmail.com>
 Philipp Wahala <philipp.wahala@gmail.com>
 Philipp Weissensteiner <mail@philippweissensteiner.com>
@@ -1741,6 +1767,7 @@ Quentin Brossard <qbrossard@gmail.com>
 Quentin Perez <qperez@ocs.online.net>
 Quentin Tayssier <qtayssier@gmail.com>
 r0n22 <cameron.regan@gmail.com>
+Rachit Sharma <rachitsharma613@gmail.com>
 Radostin Stoyanov <rstoyanov1@gmail.com>
 Rafal Jeczalik <rjeczalik@gmail.com>
 Rafe Colton <rafael.colton@gmail.com>
@@ -1773,6 +1800,7 @@ Rich Horwood <rjhorwood@apple.com>
 Rich Moyse <rich@moyse.us>
 Rich Seymour <rseymour@gmail.com>
 Richard Burnison <rburnison@ebay.com>
+Richard Hansen <rhansen@rhansen.org>
 Richard Harvey <richard@squarecows.com>
 Richard Mathie <richard.mathie@amey.co.uk>
 Richard Metzler <richard@paadee.com>
@@ -1788,6 +1816,7 @@ Ritesh H Shukla <sritesh@vmware.com>
 Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
 Rob Cowsill <42620235+rcowsill@users.noreply.github.com>
 Rob Gulewich <rgulewich@netflix.com>
+Rob Murray <rob.murray@docker.com>
 Rob Vesse <rvesse@dotnetrdf.org>
 Robert Bachmann <rb@robertbachmann.at>
 Robert Bittle <guywithnose@gmail.com>
@@ -1869,6 +1898,7 @@ ryancooper7 <ryan.cooper7@gmail.com>
 RyanDeng <sheldon.d1018@gmail.com>
 Ryo Nakao <nakabonne@gmail.com>
 Ryoga Saito <contact@proelbtn.com>
+Régis Behmo <regis@behmo.com>
 Rémy Greinhofer <remy.greinhofer@livelovely.com>
 s. rannou <mxs@sbrk.org>
 Sabin Basyal <sabin.basyal@gmail.com>
@@ -1885,6 +1915,7 @@ Sam J Sharpe <sam.sharpe@digital.cabinet-office.gov.uk>
 Sam Neirinck <sam@samneirinck.com>
 Sam Reis <sreis@atlassian.com>
 Sam Rijs <srijs@airpost.net>
+Sam Thibault <sam.thibault@docker.com>
 Sam Whited <sam@samwhited.com>
 Sambuddha Basu <sambuddhabasu1@gmail.com>
 Sami Wagiaalla <swagiaal@redhat.com>
@@ -1908,6 +1939,7 @@ Satoshi Tagomori <tagomoris@gmail.com>
 Scott Bessler <scottbessler@gmail.com>
 Scott Collier <emailscottcollier@gmail.com>
 Scott Johnston <scott@docker.com>
+Scott Moser <smoser@brickies.net>
 Scott Percival <scottp@lastyard.com>
 Scott Stamp <scottstamp851@gmail.com>
 Scott Walls <sawalls@umich.edu>
@@ -1923,6 +1955,7 @@ Sebastiaan van Steenis <mail@superseb.nl>
 Sebastiaan van Stijn <github@gone.nl>
 Sebastian Höffner <sebastian.hoeffner@mevis.fraunhofer.de>
 Sebastian Radloff <sradloff23@gmail.com>
+Sebastian Thomschke <sebthom@users.noreply.github.com>
 Sebastien Goasguen <runseb@gmail.com>
 Senthil Kumar Selvaraj <senthil.thecoder@gmail.com>
 Senthil Kumaran <senthil@uthcode.com>
@@ -1996,6 +2029,7 @@ Stanislav Bondarenko <stanislav.bondarenko@gmail.com>
 Stanislav Levin <slev@altlinux.org>
 Steeve Morin <steeve.morin@gmail.com>
 Stefan Berger <stefanb@linux.vnet.ibm.com>
+Stefan Gehrig <stefan.gehrig.hn@googlemail.com>
 Stefan J. Wernli <swernli@microsoft.com>
 Stefan Praszalowicz <stefan@greplin.com>
 Stefan S. <tronicum@user.github.com>
@@ -2003,6 +2037,7 @@ Stefan Scherer <stefan.scherer@docker.com>
 Stefan Staudenmeyer <doerte@instana.com>
 Stefan Weil <sw@weilnetz.de>
 Steffen Butzer <steffen.butzer@outlook.com>
+Stephan Henningsen <stephan-henningsen@users.noreply.github.com>
 Stephan Spindler <shutefan@gmail.com>
 Stephen Benjamin <stephen@redhat.com>
 Stephen Crosby <stevecrozz@gmail.com>
@@ -2204,6 +2239,7 @@ Vinod Kulkarni <vinod.kulkarni@gmail.com>
 Vishal Doshi <vishal.doshi@gmail.com>
 Vishnu Kannan <vishnuk@google.com>
 Vitaly Ostrosablin <vostrosablin@virtuozzo.com>
+Vitor Anjos <bartier@users.noreply.github.com>
 Vitor Monteiro <vmrmonteiro@gmail.com>
 Vivek Agarwal <me@vivek.im>
 Vivek Dasgupta <vdasgupt@redhat.com>
@@ -2250,6 +2286,7 @@ Wenxuan Zhao <viz@linux.com>
 Wenyu You <21551128@zju.edu.cn>
 Wenzhi Liang <wenzhi.liang@gmail.com>
 Wes Morgan <cap10morgan@gmail.com>
+Wesley Pettit <wppttt@amazon.com>
 Wewang Xiaorenfine <wang.xiaoren@zte.com.cn>
 Wiktor Kwapisiewicz <wiktor@metacode.biz>
 Will Dietz <w@wdtz.org>
@@ -2289,7 +2326,7 @@ xiekeyang <xiekeyang@huawei.com>
 Ximo Guanter Gonzálbez <joaquin.guantergonzalbez@telefonica.com>
 xin.li <xin.li@daocloud.io>
 Xinbo Weng <xihuanbo_0521@zju.edu.cn>
-Xinfeng Liu <xinfeng.liu@gmail.com>
+Xinfeng Liu <XinfengLiu@icloud.com>
 Xinzi Zhou <imdreamrunner@gmail.com>
 Xiuming Chen <cc@cxm.cc>
 Xuecong Liao <satorulogic@gmail.com>
@@ -2355,6 +2392,7 @@ Zen Lin(Zhinan Lin) <linzhinan@huawei.com>
 Zhang Kun <zkazure@gmail.com>
 Zhang Wei <zhangwei555@huawei.com>
 Zhang Wentao <zhangwentao234@huawei.com>
+zhangguanzhang <zhangguanzhang@qq.com>
 ZhangHang <stevezhang2014@gmail.com>
 zhangxianwei <xianwei.zw@alibaba-inc.com>
 Zhenan Ye <21551168@zju.edu.cn>
@@ -2381,6 +2419,7 @@ Zuhayr Elahi <zuhayr.elahi@docker.com>
 Zunayed Ali <zunayed@gmail.com>
 Álvaro Lázaro <alvaro.lazaro.g@gmail.com>
 Átila Camurça Alves <camurca.home@gmail.com>
+吴小白 <296015668@qq.com>
 尹吉峰 <jifeng.yin@gmail.com>
 屈骏 <qujun@tiduyun.com>
 徐俊杰 <paco.xu@daocloud.io>

--- a/vendor/github.com/docker/docker/pkg/homedir/homedir.go
+++ b/vendor/github.com/docker/docker/pkg/homedir/homedir.go
@@ -1,0 +1,44 @@
+package homedir
+
+import (
+	"os"
+	"os/user"
+	"runtime"
+)
+
+// Key returns the env var name for the user's home dir based on
+// the platform being run on.
+//
+// Deprecated: this function is no longer used, and will be removed in the next release.
+func Key() string {
+	return envKeyName
+}
+
+// Get returns the home directory of the current user with the help of
+// environment variables depending on the target operating system.
+// Returned path should be used with "path/filepath" to form new paths.
+//
+// On non-Windows platforms, it falls back to nss lookups, if the home
+// directory cannot be obtained from environment-variables.
+//
+// If linking statically with cgo enabled against glibc, ensure the
+// osusergo build tag is used.
+//
+// If needing to do nss lookups, do not disable cgo or set osusergo.
+func Get() string {
+	home, _ := os.UserHomeDir()
+	if home == "" && runtime.GOOS != "windows" {
+		if u, err := user.Current(); err == nil {
+			return u.HomeDir
+		}
+	}
+	return home
+}
+
+// GetShortcutString returns the string that is shortcut to user's home directory
+// in the native shell of the platform running on.
+//
+// Deprecated: this function is no longer used, and will be removed in the next release.
+func GetShortcutString() string {
+	return homeShortCut
+}

--- a/vendor/github.com/docker/docker/pkg/homedir/homedir_others.go
+++ b/vendor/github.com/docker/docker/pkg/homedir/homedir_others.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package homedir // import "github.com/docker/docker/pkg/homedir"
 

--- a/vendor/github.com/docker/docker/pkg/homedir/homedir_unix.go
+++ b/vendor/github.com/docker/docker/pkg/homedir/homedir_unix.go
@@ -1,39 +1,8 @@
 //go:build !windows
-// +build !windows
 
 package homedir // import "github.com/docker/docker/pkg/homedir"
 
-import (
-	"os"
-	"os/user"
+const (
+	envKeyName   = "HOME"
+	homeShortCut = "~"
 )
-
-// Key returns the env var name for the user's home dir based on
-// the platform being run on
-func Key() string {
-	return "HOME"
-}
-
-// Get returns the home directory of the current user with the help of
-// environment variables depending on the target operating system.
-// Returned path should be used with "path/filepath" to form new paths.
-//
-// If linking statically with cgo enabled against glibc, ensure the
-// osusergo build tag is used.
-//
-// If needing to do nss lookups, do not disable cgo or set osusergo.
-func Get() string {
-	home := os.Getenv(Key())
-	if home == "" {
-		if u, err := user.Current(); err == nil {
-			return u.HomeDir
-		}
-	}
-	return home
-}
-
-// GetShortcutString returns the string that is shortcut to user's home directory
-// in the native shell of the platform running on.
-func GetShortcutString() string {
-	return "~"
-}

--- a/vendor/github.com/docker/docker/pkg/homedir/homedir_windows.go
+++ b/vendor/github.com/docker/docker/pkg/homedir/homedir_windows.go
@@ -1,24 +1,6 @@
 package homedir // import "github.com/docker/docker/pkg/homedir"
 
-import (
-	"os"
+const (
+	envKeyName   = "USERPROFILE"
+	homeShortCut = "%USERPROFILE%" // be careful while using in format functions
 )
-
-// Key returns the env var name for the user's home dir based on
-// the platform being run on
-func Key() string {
-	return "USERPROFILE"
-}
-
-// Get returns the home directory of the current user with the help of
-// environment variables depending on the target operating system.
-// Returned path should be used with "path/filepath" to form new paths.
-func Get() string {
-	return os.Getenv(Key())
-}
-
-// GetShortcutString returns the string that is shortcut to user's home directory
-// in the native shell of the platform running on.
-func GetShortcutString() string {
-	return "%USERPROFILE%" // be careful while using in format functions
-}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,7 +183,7 @@ github.com/davecgh/go-spew/spew
 # github.com/dimchansky/utfbom v1.1.0
 ## explicit
 github.com/dimchansky/utfbom
-# github.com/docker/cli v24.0.0+incompatible
+# github.com/docker/cli v25.0.5+incompatible
 ## explicit
 github.com/docker/cli/cli/config
 github.com/docker/cli/cli/config/configfile
@@ -192,7 +192,7 @@ github.com/docker/cli/cli/config/types
 # github.com/docker/distribution v2.8.2+incompatible
 ## explicit
 github.com/docker/distribution/registry/client/auth/challenge
-# github.com/docker/docker v24.0.9+incompatible
+# github.com/docker/docker v25.0.5+incompatible
 ## explicit
 github.com/docker/docker/pkg/homedir
 # github.com/docker/docker-credential-helpers v0.7.0


### PR DESCRIPTION
related to https://github.com/moby/moby/pull/47538

Some of the indirect deps cannot be resolved until those project update & release, so this is incomplete but at least updates the direct deps

go mod graph output after changes:

```sh
carvel.dev/vendir github.com/docker/cli@v25.0.5+incompatible
carvel.dev/imgpkg@v0.40.0 github.com/docker/cli@v24.0.0+incompatible
github.com/google/go-containerregistry@v0.16.1 github.com/docker/cli@v24.0.0+incompatible
carvel.dev/vendir github.com/docker/docker@v25.0.5+incompatible
carvel.dev/imgpkg@v0.40.0 github.com/docker/docker@v24.0.7+incompatible
github.com/google/go-containerregistry@v0.16.1 github.com/docker/docker@v24.0.0+incompatible
```
