### PR TITLE
Introduce possibility for custom HTTP Headers in HTTP source

### DIFF
--- a/pkg/vendir/config/directory.go
+++ b/pkg/vendir/config/directory.go
@@ -102,6 +102,9 @@ type DirectoryContentsHTTP struct {
 	SecretRef *DirectoryContentsLocalRef `json:"secretRef,omitempty"`
 	// +optional
 	DisableUnpack bool `json:"disableUnpack,omitempty"`
+	// Secret containing HTTP Headers for the HTTP request when fetching the URL
+	// +optional
+	HTTPHeadersSecretRef *DirectoryContentsLocalRef `json:"httpHeadersSecretRef,omitempty"`
 }
 
 type DirectoryContentsImage struct {

--- a/pkg/vendir/fetch/http/sync.go
+++ b/pkg/vendir/fetch/http/sync.go
@@ -86,6 +86,11 @@ func (t *Sync) downloadFile(dst io.Writer) error {
 		return fmt.Errorf("Adding auth to request: %s", err)
 	}
 
+	err = t.addHTTPHeaders(req)
+	if err != nil {
+		return fmt.Errorf("Adding HTTP Headers to request: %s", err)
+	}
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("Initiating URL download: %s", err)
@@ -158,5 +163,19 @@ func (t *Sync) addAuth(req *http.Request) error {
 			string(secret.Data[ctlconf.SecretK8sCorev1BasicAuthPasswordKey]))
 	}
 
+	return nil
+}
+
+func (t *Sync) addHTTPHeaders(req *http.Request) error {
+	if t.opts.HTTPHeadersSecretRef != nil {
+		secret, err := t.refFetcher.GetSecret(t.opts.HTTPHeadersSecretRef.Name)
+		if err != nil {
+			return err
+		}
+
+		for name, value := range secret.Data {
+			req.Header.Set(name, string(value))
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
This PR introduces the possibility to add custom HTTP Headers to requests for fetching HTTP sources and thereby fixes #87. 

The custom HTTP headers for the HTTP source can be provided via a new field `httpHeadersSecretRef` in the HTTP source spec. All key value pairs from that secret will be added as HTTP Header to the HTTP request to fetch the file from the HTTP source.