### PR TITLE
Use latest github.com/carvel-dev/semver

### DIFF
--- a/examples/github-release/vendir.lock.yml
+++ b/examples/github-release/vendir.lock.yml
@@ -18,8 +18,8 @@ directories:
       url: https://api.github.com/repos/cloudfoundry/eirini-release/releases/23064766
     path: github.com/cloudfoundry-incubator/eirini-release
   - githubRelease:
-      tag: v1.23.0
-      url: https://api.github.com/repos/kubernetes/kubernetes/releases/54824547
+      tag: v1.23.17
+      url: https://api.github.com/repos/kubernetes/kubernetes/releases/94000681
     path: github.com/kubernetes/kubectl
   path: vendor
 kind: LockConfig

--- a/examples/github-release/vendir.yml
+++ b/examples/github-release/vendir.yml
@@ -48,6 +48,6 @@ directories:
       disableAutoChecksumValidation: true
       tagSelection:
         semver:
-          constraints: "~v1.23.x"
+          constraints: 1.23.x
       http:
         url: https://dl.k8s.io/release/{tag}/bin/linux/amd64/kubectl

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	carvel.dev/imgpkg v0.40.0
 	github.com/bmatcuk/doublestar v1.2.1
-	github.com/carvel-dev/semver/v4 v4.0.1-0.20230221220520-8090ce423695
+	github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4
 	github.com/cppforlife/cobrautil v0.0.0-20221021151949-d60711905d65
 	github.com/cppforlife/go-cli-ui v0.0.0-20220425131040-94f26b16bc14
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220517224237-
 github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220517224237-e6f29200ae04/go.mod h1:Z+bXnIbhKJYSvxNwsNnwde7pDKxuqlEZCbUBoTwAqf0=
 github.com/bmatcuk/doublestar v1.2.1 h1:eetYiv8DDYOZcBADY+pRvRytf3Dlz1FhnpvL2FsClBc=
 github.com/bmatcuk/doublestar v1.2.1/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
-github.com/carvel-dev/semver/v4 v4.0.1-0.20230221220520-8090ce423695 h1:naCDnpJeqQq5OHOYR6j01yIVVUk3WI5MuSHpDTy+M1A=
-github.com/carvel-dev/semver/v4 v4.0.1-0.20230221220520-8090ce423695/go.mod h1:4cFTBLAr/U11ykiEEQMccu4uJ1i0GS+atJmeETHCFtI=
+github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4 h1:F4rZiMGZyC66j9VB7doVOE4tFHF1yNEihQlOuht4jmM=
+github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4/go.mod h1:4cFTBLAr/U11ykiEEQMccu4uJ1i0GS+atJmeETHCFtI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb/v3 v3.1.4 h1:DN8j4TVVdKu3WxVwcRKu0sG00IIU6FewoABZzXbRQeo=
 github.com/cheggaaa/pb/v3 v3.1.4/go.mod h1:6wVjILNBaXMs8c21qRiaUM8BR82erfgau1DQ4iUXmSA=

--- a/vendor/github.com/carvel-dev/semver/v4/range.go
+++ b/vendor/github.com/carvel-dev/semver/v4/range.go
@@ -67,8 +67,8 @@ func (vr *versionRange) rangeFunc() Range {
 // Range represents a range of versions.
 // A Range can be used to check if a Version satisfies it:
 //
-//     range, err := semver.ParseRange(">1.0.0 <2.0.0")
-//     range(semver.MustParse("1.1.1") // returns true
+//	range, err := semver.ParseRange(">1.0.0 <2.0.0")
+//	range(semver.MustParse("1.1.1") // returns true
 type Range func(Version) bool
 
 // OR combines the existing Range with another Range using logical OR.
@@ -108,7 +108,7 @@ func (rf Range) AND(f Range) Range {
 //
 // Ranges can be combined by both AND and OR
 //
-//  - `>1.0.0 <2.0.0 || >3.0.0 !4.2.1` would match `1.2.3`, `1.9.9`, `3.1.1`, but not `4.2.1`, `2.1.1`
+//   - `>1.0.0 <2.0.0 || >3.0.0 !4.2.1` would match `1.2.3`, `1.9.9`, `3.1.1`, but not `4.2.1`, `2.1.1`
 func ParseRange(s string) (Range, error) {
 	parts := splitAndTrim(s)
 	orParts, err := splitORParts(parts)
@@ -269,10 +269,10 @@ func createVersionFromWildcard(vStr string) string {
 
 	// handle 1.x
 	if len(parts) == 2 {
-		return vStr2 + ".0"
+		vStr2 = vStr2 + ".0"
 	}
 
-	return vStr2
+	return vStr2 + "-0"
 }
 
 // incrementMajorVersion will increment the major version
@@ -327,12 +327,12 @@ func expandWildcardVersion(parts [][]string) ([][]string, error) {
 	for _, p := range parts {
 		var newParts []string
 		for _, ap := range p {
-			if strings.Contains(ap, "x") {
-				opStr, vStr, err := splitComparatorVersion(ap)
-				if err != nil {
-					return nil, err
-				}
+			opStr, vStr, err := splitComparatorVersion(ap)
+			if err != nil {
+				return nil, err
+			}
 
+			if containsWildcard(ap) {
 				versionWildcardType := getWildcardType(vStr)
 				flatVersion := createVersionFromWildcard(vStr)
 
@@ -379,6 +379,16 @@ func expandWildcardVersion(parts [][]string) ([][]string, error) {
 	}
 
 	return expandedParts, nil
+}
+
+// containsWildcard returns true if there's a wildcard in any of the major, minor or patch components
+func containsWildcard(v string) bool {
+	return strings.Contains(trimIdentifiers(v), ".x")
+}
+
+// trimIdentifiers removes any pre-release and build metadata from a version
+func trimIdentifiers(v string) string {
+  return strings.Split(strings.Split(v, "+")[0], "-")[0]
 }
 
 func parseComparator(s string) comparator {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -150,7 +150,7 @@ github.com/awslabs/amazon-ecr-credential-helper/ecr-login/version
 # github.com/bmatcuk/doublestar v1.2.1
 ## explicit; go 1.12
 github.com/bmatcuk/doublestar
-# github.com/carvel-dev/semver/v4 v4.0.1-0.20230221220520-8090ce423695
+# github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4
 ## explicit; go 1.14
 github.com/carvel-dev/semver/v4
 # github.com/cheggaaa/pb/v3 v3.1.4


### PR DESCRIPTION
* migrates `github.com/{k14s → carvel-dev}/semver/v4`
* bumps to latest `github.com/carvel-dev/semver/v4`
* updates `examples/github-release/vendir.yml` to select `kubectl` against constraint `1.23.x` instead of `~v1.23.x` which is not a valid range
* fixes https://github.com/carvel-dev/vendir/issues/123