### PR TITLE
git: add a cache based on bundles

### DIFF
--- a/pkg/vendir/directory/directory.go
+++ b/pkg/vendir/directory/directory.go
@@ -112,7 +112,7 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 			d.ui.PrintLinef("Fetching: %s + %s (git from %s)", d.opts.Path, contents.Path, gitSync.Desc())
 
-			lock, err := gitSync.Sync(stagingDstPath, stagingDir.TempArea())
+			lock, err := gitSync.Sync(stagingDstPath, stagingDir.TempArea(), syncOpts.Cache)
 			if err != nil {
 				return lockConfig, fmt.Errorf("Syncing directory '%s' with git contents: %s", contents.Path, err)
 			}

--- a/pkg/vendir/directory/directory.go
+++ b/pkg/vendir/directory/directory.go
@@ -108,11 +108,11 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 		switch {
 		case contents.Git != nil:
-			gitSync := ctlgit.NewSync(*contents.Git, NewInfoLog(d.ui), syncOpts.RefFetcher)
+			gitSync := ctlgit.NewSync(*contents.Git, NewInfoLog(d.ui), syncOpts.RefFetcher, syncOpts.Cache)
 
 			d.ui.PrintLinef("Fetching: %s + %s (git from %s)", d.opts.Path, contents.Path, gitSync.Desc())
 
-			lock, err := gitSync.Sync(stagingDstPath, stagingDir.TempArea(), syncOpts.Cache)
+			lock, err := gitSync.Sync(stagingDstPath, stagingDir.TempArea())
 			if err != nil {
 				return lockConfig, fmt.Errorf("Syncing directory '%s' with git contents: %s", contents.Path, err)
 			}

--- a/pkg/vendir/fetch/git/git.go
+++ b/pkg/vendir/fetch/git/git.go
@@ -47,12 +47,12 @@ type GitInfo struct {
 	CommitTitle string
 }
 
-func (t *Git) Retrieve(dstPath string, tempArea ctlfetch.TempArea) (GitInfo, error) {
+func (t *Git) Retrieve(dstPath string, tempArea ctlfetch.TempArea, bundle string) (GitInfo, error) {
 	if len(t.opts.URL) == 0 {
 		return GitInfo{}, fmt.Errorf("Expected non-empty URL")
 	}
 
-	err := t.fetch(dstPath, tempArea)
+	err := t.fetch(dstPath, tempArea, bundle)
 	if err != nil {
 		return GitInfo{}, err
 	}
@@ -81,7 +81,7 @@ func (t *Git) Retrieve(dstPath string, tempArea ctlfetch.TempArea) (GitInfo, err
 	return info, nil
 }
 
-func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea) error {
+func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) error {
 	authOpts, err := t.getAuthOpts()
 	if err != nil {
 		return err
@@ -167,6 +167,10 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea) error {
 	}
 
 	argss = append(argss, []string{"config", "remote.origin.tagOpt", "--tags"})
+
+	if bundle != "" {
+		argss = append(argss, []string{"bundle", "unbundle", bundle})
+	}
 
 	{
 		fetchArgs := []string{"fetch", "origin"}

--- a/pkg/vendir/fetch/git/git_test.go
+++ b/pkg/vendir/fetch/git/git_test.go
@@ -32,7 +32,7 @@ func TestGit_Retrieve(t *testing.T) {
 			SecretRef:          &config.DirectoryContentsLocalRef{Name: "some-secret"},
 			ForceHTTPBasicAuth: true,
 		}, os.Stdout, secretFetcher, runner)
-		_, err := gitRetriever.Retrieve("", &tmpFolder{t})
+		_, err := gitRetriever.Retrieve("", &tmpFolder{t}, "")
 		require.NoError(t, err)
 		isPresent := false
 		// Check that the header was added with the correct values
@@ -62,7 +62,7 @@ func TestGit_Retrieve(t *testing.T) {
 			SecretRef:          &config.DirectoryContentsLocalRef{Name: "some-secret"},
 			ForceHTTPBasicAuth: true,
 		}, os.Stdout, secretFetcher, runner)
-		_, err := gitRetriever.Retrieve("", &tmpFolder{t})
+		_, err := gitRetriever.Retrieve("", &tmpFolder{t}, "")
 		require.ErrorContains(t, err, "Username/password authentication is only supported for https remotes")
 	})
 }

--- a/test/e2e/git_test.go
+++ b/test/e2e/git_test.go
@@ -146,19 +146,14 @@ func TestGitCache(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	gitSrcPath, err := os.MkdirTemp("", "vendir-e2e-git-verify-signed-git-repo")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer os.RemoveAll(gitSrcPath)
 
-	if out, err := exec.Command("tar", "xzvf", "assets/git-repo-signed/asset.tgz", "-C", gitSrcPath).CombinedOutput(); err != nil {
-		t.Fatalf("Unpacking git-repo-signed asset: %s (output: '%s')", err, out)
-	}
+	out, err := exec.Command("tar", "xzvf", "assets/git-repo-signed/asset.tgz", "-C", gitSrcPath).CombinedOutput()
+	require.NoErrorf(t, err, "Unpacking git-repo-signed asset: %s (output: '%s')", err, out)
 
 	dstPath, err := os.MkdirTemp("", "vendir-e2e-git-verify-signed-dst")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer os.RemoveAll(dstPath)
 
 	trustedPubKey := readFile(t, filepath.Join(gitSrcPath, "keys/trusted.pub"))
@@ -208,10 +203,10 @@ directories:
 			},
 		})
 
-	var out hgVendirOutput
-	require.NoError(t, stdoutDec.Decode(&out))
+	var vendirOutput VendirOutput
+	require.NoError(t, stdoutDec.Decode(&vendirOutput))
 
-	for _, l := range out.Lines {
+	for _, l := range vendirOutput.Lines {
 		assert.NotContains(t, l, "unbundle")
 	}
 
@@ -229,15 +224,15 @@ directories:
 			},
 		})
 
-	require.NoError(t, stdoutDec.Decode(&out))
+	require.NoError(t, stdoutDec.Decode(&vendirOutput))
 
 	var unbundled bool
-	for _, l := range out.Lines {
+	for _, l := range vendirOutput.Lines {
 		if strings.Contains(l, "unbundle") {
 			unbundled = true
 		}
 	}
-	assert.True(t, unbundled, "git did not use the cached bundle")
+	require.True(t, unbundled, "git did not use the cached bundle")
 }
 
 func readFile(t *testing.T, path string) string {

--- a/test/e2e/hg_test.go
+++ b/test/e2e/hg_test.go
@@ -25,12 +25,6 @@ type HgAssetInfo struct {
 	ExtraChangeset   string `json:"extra-changeset"`
 }
 
-type hgVendirOutput struct {
-	Tables string
-	Blocks []string
-	Lines  []string
-}
-
 func loadHgAssetInfo(t *testing.T, filename string) HgAssetInfo {
 	t.Helper()
 	f, err := os.Open(filename)
@@ -92,7 +86,7 @@ directories:
 				Env:          []string{"VENDIR_CACHE_DIR=" + cachePath},
 			})
 
-		var out hgVendirOutput
+		var out VendirOutput
 		require.NoError(t, stdoutDec.Decode(&out))
 
 		assert.Contains(t, out.Lines[1], "init")
@@ -114,7 +108,7 @@ directories:
 				Env:          []string{"VENDIR_CACHE_DIR=" + cachePath},
 			})
 
-		var out hgVendirOutput
+		var out VendirOutput
 		require.NoError(t, stdoutDec.Decode(&out))
 
 		for _, line := range out.Lines {
@@ -145,7 +139,7 @@ directories:
 				Env:          []string{"VENDIR_CACHE_DIR=" + cachePath},
 			})
 
-		var out hgVendirOutput
+		var out VendirOutput
 		require.NoError(t, stdoutDec.Decode(&out))
 
 		assert.Contains(t, out.Lines[3], "pull")

--- a/test/e2e/vendir.go
+++ b/test/e2e/vendir.go
@@ -30,6 +30,13 @@ type RunOpts struct {
 	Env          []string
 }
 
+// VendirOutput allows parsing of the --json vendir output
+type VendirOutput struct {
+	Tables string
+	Blocks []string
+	Lines  []string
+}
+
 func (k Vendir) Run(args []string) string {
 	out, _ := k.RunWithOpts(args, RunOpts{})
 	return out


### PR DESCRIPTION
The cache strategy is simpler than the one I did for mercurial, and a little less efficient (it is slower).
But it is solid, and avoids a cumbersome refactoring of the fetcher.