### PR TITLE
fix: avoid panic by checking response for nil

### DIFF
--- a/pkg/vendir/fetch/githubrelease/sync.go
+++ b/pkg/vendir/fetch/githubrelease/sync.go
@@ -435,7 +435,7 @@ func (d Sync) authToken() (string, error) {
 		}
 	}
 
-	return token, nil
+	return strings.TrimSpace(token), nil
 }
 
 type ReleaseAPI struct {

--- a/pkg/vendir/fetch/githubrelease/sync.go
+++ b/pkg/vendir/fetch/githubrelease/sync.go
@@ -244,11 +244,13 @@ func (d Sync) fetchTagSelection() (string, error) {
 		tagList, resp, err := d.client.Repositories.ListTags(context.Background(), ownerName, repoName, &listOpt)
 		if err != nil {
 			errMsg := err.Error()
-			switch resp.StatusCode {
-			case 401, 403:
-				hintMsg := "(hint: consider setting VENDIR_GITHUB_API_TOKEN env variable to increase API rate limits)"
-				bs, _ := io.ReadAll(resp.Body)
-				errMsg += fmt.Sprintf(" %s (body: '%s')", hintMsg, bs)
+			if resp != nil {
+				switch resp.StatusCode {
+				case 401, 403:
+					hintMsg := "(hint: consider setting VENDIR_GITHUB_API_TOKEN env variable to increase API rate limits)"
+					bs, _ := io.ReadAll(resp.Body)
+					errMsg += fmt.Sprintf(" %s (body: '%s')", hintMsg, bs)
+				}
 			}
 			return "", fmt.Errorf("Downloading tags info: %s", errMsg)
 		}


### PR DESCRIPTION
Fixes #389.

This PR addresses two issues:

- panic in case of malformed API token
- accidental trailing spaces in the token value

If the authorization header value contains a trailing newline, the http client returns error without a response struct (`nil`).

It is easy to miss a trailing newline when encoding a value into base64. To avoid inconvenience for users, let's trim it.