### PR TITLE
Stricter caching for imgpkg bundles

### DIFF
--- a/pkg/vendir/fetch/image/imgpkg.go
+++ b/pkg/vendir/fetch/image/imgpkg.go
@@ -63,8 +63,8 @@ func (t *Imgpkg) FetchBundleRecursively(imageRef, destination string) (string, e
 		return "", err
 	}
 
-	if _, hit := t.cache.Has(ImgpkgBundleArtifactType, ref.Identifier()); hit {
-		return imageRef, t.cache.CopyFrom(ImgpkgBundleArtifactType, ref.Identifier(), destination)
+	if _, hit := t.cache.Has(ImgpkgBundleArtifactType, ref.Name()); hit {
+		return imageRef, t.cache.CopyFrom(ImgpkgBundleArtifactType, ref.Name(), destination)
 	}
 
 	opts, err := t.RegistryOpts()
@@ -83,7 +83,7 @@ func (t *Imgpkg) FetchBundleRecursively(imageRef, destination string) (string, e
 	}
 
 	if status.Cacheable {
-		err := t.cache.Save(ImgpkgBundleArtifactType, ref.Identifier(), destination)
+		err := t.cache.Save(ImgpkgBundleArtifactType, ref.Name(), destination)
 		if err != nil {
 			return "", err
 		}
@@ -103,8 +103,8 @@ func (t *Imgpkg) fetch(imageRef, destination string, isBundle bool) (string, err
 		return "", err
 	}
 
-	if _, hit := t.cache.Has(artifactType, ref.Identifier()); hit {
-		return imageRef, t.cache.CopyFrom(artifactType, ref.Identifier(), destination)
+	if _, hit := t.cache.Has(artifactType, ref.Name()); hit {
+		return imageRef, t.cache.CopyFrom(artifactType, ref.Name(), destination)
 	}
 
 	opts, err := t.RegistryOpts()
@@ -123,7 +123,7 @@ func (t *Imgpkg) fetch(imageRef, destination string, isBundle bool) (string, err
 	}
 
 	if status.Cacheable {
-		err := t.cache.Save(artifactType, ref.Identifier(), destination)
+		err := t.cache.Save(artifactType, ref.Name(), destination)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Use a fully-qualified reference as key for a cache rather than the digest.

Resolves #399 and eventually carvel-dev/kapp-controller#1603