### PR TITLE
feat: git sparse checkout

### DIFF
--- a/pkg/vendir/config/config.go
+++ b/pkg/vendir/config/config.go
@@ -178,13 +178,15 @@ func (c Config) UseDirectory(path, dirPath string) error {
 			matched = true
 
 			newCon := DirectoryContents{
-				Path:         con.Path,
-				Directory:    &DirectoryContentsDirectory{Path: dirPath},
-				IncludePaths: con.IncludePaths,
-				ExcludePaths: con.ExcludePaths,
-				IgnorePaths:  con.IgnorePaths,
-				LegalPaths:   con.LegalPaths,
-				Lazy:         con.Lazy,
+				Path:      con.Path,
+				Directory: &DirectoryContentsDirectory{Path: dirPath},
+				ContentPaths: ContentPaths{
+					IncludePaths: con.IncludePaths,
+					ExcludePaths: con.ExcludePaths,
+					IgnorePaths:  con.IgnorePaths,
+				},
+				LegalPaths: con.LegalPaths,
+				Lazy:       con.Lazy,
 			}
 			dir.Contents[j] = newCon
 			c.Directories[i] = dir

--- a/pkg/vendir/config/directory.go
+++ b/pkg/vendir/config/directory.go
@@ -46,17 +46,18 @@ type DirectoryContents struct {
 	Manual        *DirectoryContentsManual        `json:"manual,omitempty"`
 	Directory     *DirectoryContentsDirectory     `json:"directory,omitempty"`
 	Inline        *DirectoryContentsInline        `json:"inline,omitempty"`
-
-	IncludePaths []string `json:"includePaths,omitempty"`
-	ExcludePaths []string `json:"excludePaths,omitempty"`
-	IgnorePaths  []string `json:"ignorePaths,omitempty"`
+	Permissions   *os.FileMode                    `json:"permissions,omitempty"`
+	NewRootPath   string                          `json:"newRootPath,omitempty"`
+	ContentPaths  `json:",inline"`
 
 	// By default LICENSE/LICENCE/NOTICE/COPYRIGHT files are kept
 	LegalPaths *[]string `json:"legalPaths,omitempty"`
+}
 
-	NewRootPath string `json:"newRootPath,omitempty"`
-
-	Permissions *os.FileMode `json:"permissions,omitempty"`
+type ContentPaths struct {
+	IncludePaths []string `json:"includePaths,omitempty"`
+	ExcludePaths []string `json:"excludePaths,omitempty"`
+	IgnorePaths  []string `json:"ignorePaths,omitempty"`
 }
 
 type DirectoryContentsGit struct {
@@ -73,6 +74,7 @@ type DirectoryContentsGit struct {
 	SkipInitSubmodules     bool `json:"skipInitSubmodules,omitempty"`
 	Depth                  int  `json:"depth,omitempty"`
 	ForceHTTPBasicAuth     bool `json:"forceHTTPBasicAuth,omitempty"`
+	SparseCheckout         bool `json:"sparseCheckout,omitempty"`
 }
 
 type DirectoryContentsGitVerification struct {

--- a/pkg/vendir/directory/directory.go
+++ b/pkg/vendir/directory/directory.go
@@ -108,7 +108,8 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 		switch {
 		case contents.Git != nil:
-			gitSync := ctlgit.NewSync(*contents.Git, NewInfoLog(d.ui), syncOpts.RefFetcher, syncOpts.Cache)
+			contentPaths := contents.ContentPaths
+			gitSync := ctlgit.NewSync(*contents.Git, contentPaths, NewInfoLog(d.ui), syncOpts.RefFetcher, syncOpts.Cache)
 
 			d.ui.PrintLinef("Fetching: %s + %s (git from %s)", d.opts.Path, contents.Path, gitSync.Desc())
 

--- a/pkg/vendir/fetch/git/git_test.go
+++ b/pkg/vendir/fetch/git/git_test.go
@@ -31,7 +31,7 @@ func TestGit_Retrieve(t *testing.T) {
 			Ref:                "origin/main",
 			SecretRef:          &config.DirectoryContentsLocalRef{Name: "some-secret"},
 			ForceHTTPBasicAuth: true,
-		}, os.Stdout, secretFetcher, runner)
+		}, config.ContentPaths{}, os.Stdout, secretFetcher, runner)
 		_, err := gitRetriever.Retrieve("", &tmpFolder{t}, "")
 		require.NoError(t, err)
 		isPresent := false
@@ -61,7 +61,7 @@ func TestGit_Retrieve(t *testing.T) {
 			Ref:                "origin/main",
 			SecretRef:          &config.DirectoryContentsLocalRef{Name: "some-secret"},
 			ForceHTTPBasicAuth: true,
-		}, os.Stdout, secretFetcher, runner)
+		}, config.ContentPaths{}, os.Stdout, secretFetcher, runner)
 		_, err := gitRetriever.Retrieve("", &tmpFolder{t}, "")
 		require.ErrorContains(t, err, "Username/password authentication is only supported for https remotes")
 	})

--- a/pkg/vendir/fetch/git/sync.go
+++ b/pkg/vendir/fetch/git/sync.go
@@ -19,16 +19,17 @@ import (
 const gitCacheType = "git-bundle"
 
 type Sync struct {
-	opts       ctlconf.DirectoryContentsGit
-	log        io.Writer
-	refFetcher ctlfetch.RefFetcher
-	cache      ctlcache.Cache
+	opts         ctlconf.DirectoryContentsGit
+	contentPaths ctlconf.ContentPaths
+	log          io.Writer
+	refFetcher   ctlfetch.RefFetcher
+	cache        ctlcache.Cache
 }
 
-func NewSync(opts ctlconf.DirectoryContentsGit,
-	log io.Writer, refFetcher ctlfetch.RefFetcher, cache ctlcache.Cache) Sync {
-
-	return Sync{opts, log, refFetcher, cache}
+func NewSync(opts ctlconf.DirectoryContentsGit, contentPaths ctlconf.ContentPaths,
+	log io.Writer, refFetcher ctlfetch.RefFetcher, cache ctlcache.Cache,
+) Sync {
+	return Sync{opts, contentPaths, log, refFetcher, cache}
 }
 
 func (d Sync) Desc() string {
@@ -54,7 +55,7 @@ func (d Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDire
 
 	cacheID := fmt.Sprintf("%x", sha256.Sum256([]byte(d.opts.URL)))
 
-	git := NewGit(d.opts, d.log, d.refFetcher)
+	git := NewGit(d.opts, d.contentPaths, d.log, d.refFetcher)
 
 	var bundle string
 	if cacheEntry, hasCache := d.cache.Has(gitCacheType, cacheID); hasCache {


### PR DESCRIPTION
Uses includePaths and excludePaths to configure non-cone sparse checkout
for a git repo.

Fixes #400

Signed-off-by: Zoltán Reegn <zoltan.reegn@gmail.com>
