### PR TITLE
fix: ST1005 error strings should not be capitalized

### DIFF
--- a/pkg/vendir/cmd/sync.go
+++ b/pkg/vendir/cmd/sync.go
@@ -63,7 +63,7 @@ func (o *SyncOptions) Run() error {
 	if len(o.Chdir) > 0 {
 		err := os.Chdir(o.Chdir)
 		if err != nil {
-			return fmt.Errorf("Running chdir: %s", err)
+			return fmt.Errorf("running chdir: %s", err)
 		}
 	}
 
@@ -125,7 +125,7 @@ func (o *SyncOptions) Run() error {
 
 	cache, err := ctlcache.NewCache(os.Getenv("VENDIR_CACHE_DIR"), maxCacheableContentSize)
 	if err != nil {
-		return fmt.Errorf("Unable to create cache: %s", err)
+		return fmt.Errorf("unable to create cache: %s", err)
 	}
 	syncOpts := ctldir.SyncOpts{
 		RefFetcher:     ctldir.NewNamedRefFetcher(secrets, configMaps),
@@ -143,7 +143,7 @@ func (o *SyncOptions) Run() error {
 		directory := ctldir.NewDirectory(dirConf, dirExistingLockConf, o.ui)
 		dirLockConf, err := directory.Sync(syncOpts)
 		if err != nil {
-			return fmt.Errorf("Syncing directory '%s': %s", dirConf.Path, err)
+			return fmt.Errorf("syncing directory '%s': %s", dirConf.Path, err)
 		}
 		if !o.AllowAllSymlinkDestinations {
 			err = ctldir.ValidateSymlinks(dirConf.Path)
@@ -217,7 +217,7 @@ func (o *SyncOptions) applyUseDirectories(conf *ctlconf.Config, dirs []dirOverri
 
 		err := conf.UseDirectory(dir.Path, dir.LocalDir)
 		if err != nil {
-			return false, fmt.Errorf("Overriding '%s' with local directory: %s", dir.Path, err)
+			return false, fmt.Errorf("overriding '%s' with local directory: %s", dir.Path, err)
 		}
 	}
 	return usesLocalDir, nil
@@ -276,7 +276,7 @@ func (dirs dirOverrides) ExpandUserHomeDirs() error {
 func (dirOverrides) userHomeDir() (string, error) {
 	out, err := homedir.Dir()
 	if err != nil {
-		return "", fmt.Errorf("Expanding user home directory: %s", err)
+		return "", fmt.Errorf("expanding user home directory: %s", err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/pkg/vendir/config/config.go
+++ b/pkg/vendir/config/config.go
@@ -38,7 +38,7 @@ func NewConfigFromFiles(paths []string) (Config, []Secret, []ConfigMap, error) {
 
 		err := yaml.Unmarshal(docBytes, &res)
 		if err != nil {
-			return fmt.Errorf("Unmarshaling doc: %s", err)
+			return fmt.Errorf("unmarshaling doc: %s", err)
 		}
 
 		switch {
@@ -47,7 +47,7 @@ func NewConfigFromFiles(paths []string) (Config, []Secret, []ConfigMap, error) {
 
 			err := yaml.Unmarshal(docBytes, &secret)
 			if err != nil {
-				return fmt.Errorf("Unmarshaling secret: %s", err)
+				return fmt.Errorf("unmarshaling secret: %s", err)
 			}
 
 			if s, ok := secretsNames[secret.Metadata.Name]; ok {
@@ -63,7 +63,7 @@ func NewConfigFromFiles(paths []string) (Config, []Secret, []ConfigMap, error) {
 
 			err := yaml.Unmarshal(docBytes, &cm)
 			if err != nil {
-				return fmt.Errorf("Unmarshaling config map: %s", err)
+				return fmt.Errorf("unmarshaling config map: %s", err)
 			}
 			configMaps = append(configMaps, cm)
 
@@ -71,12 +71,12 @@ func NewConfigFromFiles(paths []string) (Config, []Secret, []ConfigMap, error) {
 			config, err := NewConfigFromBytes(docBytes)
 			config.cleanPaths()
 			if err != nil {
-				return fmt.Errorf("Unmarshaling config: %s", err)
+				return fmt.Errorf("unmarshaling config: %s", err)
 			}
 			configs = append(configs, config)
 
 		default:
-			return fmt.Errorf("Unknown apiVersion '%s' or kind '%s' for resource",
+			return fmt.Errorf("unknown apiVersion '%s' or kind '%s' for resource",
 				res.APIVersion, res.Kind)
 		}
 		return nil
@@ -91,10 +91,10 @@ func NewConfigFromFiles(paths []string) (Config, []Secret, []ConfigMap, error) {
 	}
 
 	if len(configs) == 0 {
-		return Config{}, nil, nil, fmt.Errorf("Expected to find at least one config, but found none")
+		return Config{}, nil, nil, fmt.Errorf("expected to find at least one config, but found none")
 	}
 	if len(configs) > 1 {
-		return Config{}, nil, nil, fmt.Errorf("Expected to find exactly one config, but found multiple")
+		return Config{}, nil, nil, fmt.Errorf("expected to find exactly one config, but found multiple")
 	}
 
 	return configs[0], secrets, configMaps, nil
@@ -105,12 +105,12 @@ func NewConfigFromBytes(bs []byte) (Config, error) {
 
 	err := yaml.Unmarshal(bs, &config)
 	if err != nil {
-		return Config{}, fmt.Errorf("Unmarshaling config: %s", err)
+		return Config{}, fmt.Errorf("unmarshaling config: %s", err)
 	}
 
 	err = config.Validate()
 	if err != nil {
-		return Config{}, fmt.Errorf("Validating config: %s", err)
+		return Config{}, fmt.Errorf("validating config: %s", err)
 	}
 
 	return config, nil
@@ -118,25 +118,25 @@ func NewConfigFromBytes(bs []byte) (Config, error) {
 
 func (c Config) Validate() error {
 	if c.APIVersion != knownAPIVersion {
-		return fmt.Errorf("Validating apiVersion: Unknown version (known: %s)", knownAPIVersion)
+		return fmt.Errorf("validating apiVersion: Unknown version (known: %s)", knownAPIVersion)
 	}
 	if c.Kind != knownKind {
-		return fmt.Errorf("Validating kind: Unknown kind (known: %s)", knownKind)
+		return fmt.Errorf("validating kind: Unknown kind (known: %s)", knownKind)
 	}
 
 	if len(c.MinimumRequiredVersion) > 0 {
 		if c.MinimumRequiredVersion[0] == 'v' {
-			return fmt.Errorf("Validating minimum version: Must not have prefix 'v' (e.g. '0.8.0')")
+			return fmt.Errorf("validating minimum version: Must not have prefix 'v' (e.g. '0.8.0')")
 		}
 
 		userConstraint, err := semver.NewConstraint(">=" + c.MinimumRequiredVersion)
 		if err != nil {
-			return fmt.Errorf("Parsing minimum version constraint: %s", err)
+			return fmt.Errorf("parsing minimum version constraint: %s", err)
 		}
 
 		vendirVersion, err := semver.NewVersion(version.Version)
 		if err != nil {
-			return fmt.Errorf("Parsing version constraint: %s", err)
+			return fmt.Errorf("parsing version constraint: %s", err)
 		}
 
 		if !userConstraint.Check(vendirVersion) {
@@ -148,7 +148,7 @@ func (c Config) Validate() error {
 	for i, dir := range c.Directories {
 		err := dir.Validate()
 		if err != nil {
-			return fmt.Errorf("Validating directory '%s' (%d): %s", dir.Path, i, err)
+			return fmt.Errorf("validating directory '%s' (%d): %s", dir.Path, i, err)
 		}
 	}
 
@@ -158,7 +158,7 @@ func (c Config) Validate() error {
 func (c Config) AsBytes() ([]byte, error) {
 	bs, err := yaml.Marshal(c)
 	if err != nil {
-		return nil, fmt.Errorf("Marshaling config: %s", err)
+		return nil, fmt.Errorf("marshaling config: %s", err)
 	}
 
 	return bs, nil
@@ -173,7 +173,7 @@ func (c Config) UseDirectory(path, dirPath string) error {
 				continue
 			}
 			if matched {
-				return fmt.Errorf("Expected to match exactly one directory, but matched multiple")
+				return fmt.Errorf("expected to match exactly one directory, but matched multiple")
 			}
 			matched = true
 
@@ -192,7 +192,7 @@ func (c Config) UseDirectory(path, dirPath string) error {
 	}
 
 	if !matched {
-		return fmt.Errorf("Expected to match exactly one directory, but did not match any")
+		return fmt.Errorf("expected to match exactly one directory, but did not match any")
 	}
 	return nil
 }
@@ -220,7 +220,7 @@ func (c Config) Subset(paths []string) (Config, error) {
 				continue
 			}
 			if seen {
-				return Config{}, fmt.Errorf("Expected to match path '%s' once, but matched multiple", entirePath)
+				return Config{}, fmt.Errorf("expected to match path '%s' once, but matched multiple", entirePath)
 			}
 			pathsToSeen[entirePath] = true
 
@@ -234,7 +234,7 @@ func (c Config) Subset(paths []string) (Config, error) {
 
 	for path, seen := range pathsToSeen {
 		if !seen {
-			return Config{}, fmt.Errorf("Expected to match path '%s' once, but did not match any", path)
+			return Config{}, fmt.Errorf("expected to match path '%s' once, but did not match any", path)
 		}
 	}
 
@@ -265,7 +265,7 @@ func (c Config) checkOverlappingPaths() error {
 		for i, path := range paths {
 			for i2, path2 := range paths {
 				if i != i2 && strings.HasPrefix(path2+string(filepath.Separator), path+string(filepath.Separator)) {
-					return fmt.Errorf("Expected to not manage overlapping paths: '%s' and '%s'", path2, path)
+					return fmt.Errorf("expected to not manage overlapping paths: '%s' and '%s'", path2, path)
 				}
 			}
 		}

--- a/pkg/vendir/config/directory.go
+++ b/pkg/vendir/config/directory.go
@@ -227,14 +227,14 @@ func (c Directory) Validate() error {
 			}
 		}
 		if consumesEntireDir && len(c.Contents) != 1 {
-			return fmt.Errorf("Expected only one directory contents if path is set to '%s'", EntireDirPath)
+			return fmt.Errorf("expected only one directory contents if path is set to '%s'", EntireDirPath)
 		}
 	}
 
 	for i, con := range c.Contents {
 		err := con.Validate()
 		if err != nil {
-			return fmt.Errorf("Validating directory contents '%s' (%d): %s", con.Path, i, err)
+			return fmt.Errorf("validating directory contents '%s' (%d): %s", con.Path, i, err)
 		}
 	}
 
@@ -276,10 +276,10 @@ func (c DirectoryContents) Validate() error {
 	}
 
 	if len(srcTypes) == 0 {
-		return fmt.Errorf("Expected directory contents type to be specified (one of git, manual, etc.)")
+		return fmt.Errorf("expected directory contents type to be specified (one of git, manual, etc.)")
 	}
 	if len(srcTypes) > 1 {
-		return fmt.Errorf("Expected exactly one directory contents type to be specified (multiple found: %s)", strings.Join(srcTypes, ", "))
+		return fmt.Errorf("expected exactly one directory contents type to be specified (multiple found: %s)", strings.Join(srcTypes, ", "))
 	}
 
 	// entire dir path is allowed for contents
@@ -307,7 +307,7 @@ func (c DirectoryContents) LegalPathsWithDefaults() []string {
 func isDisallowedPath(path string) error {
 	for _, p := range disallowedPaths {
 		if path == p {
-			return fmt.Errorf("Expected path to not be one of '%s'",
+			return fmt.Errorf("expected path to not be one of '%s'",
 				strings.Join(disallowedPaths, "', '"))
 		}
 	}
@@ -343,10 +343,10 @@ func (c DirectoryContents) Lock(lockConfig LockDirectoryContents) error {
 
 func (c *DirectoryContentsGit) Lock(lockConfig *LockDirectoryContentsGit) error {
 	if lockConfig == nil {
-		return fmt.Errorf("Expected git lock configuration to be non-empty")
+		return fmt.Errorf("expected git lock configuration to be non-empty")
 	}
 	if len(lockConfig.SHA) == 0 {
-		return fmt.Errorf("Expected git SHA to be non-empty")
+		return fmt.Errorf("expected git SHA to be non-empty")
 	}
 	c.Ref = lockConfig.SHA
 	return nil
@@ -354,10 +354,10 @@ func (c *DirectoryContentsGit) Lock(lockConfig *LockDirectoryContentsGit) error 
 
 func (c *DirectoryContentsHg) Lock(lockConfig *LockDirectoryContentsHg) error {
 	if lockConfig == nil {
-		return fmt.Errorf("Expected hg lock configuration to be non-empty")
+		return fmt.Errorf("expected hg lock configuration to be non-empty")
 	}
 	if len(lockConfig.SHA) == 0 {
-		return fmt.Errorf("Expected hg SHA to be non-empty")
+		return fmt.Errorf("expected hg SHA to be non-empty")
 	}
 	c.Ref = lockConfig.SHA
 	return nil
@@ -365,17 +365,17 @@ func (c *DirectoryContentsHg) Lock(lockConfig *LockDirectoryContentsHg) error {
 
 func (c *DirectoryContentsHTTP) Lock(lockConfig *LockDirectoryContentsHTTP) error {
 	if lockConfig == nil {
-		return fmt.Errorf("Expected HTTP lock configuration to be non-empty")
+		return fmt.Errorf("expected HTTP lock configuration to be non-empty")
 	}
 	return nil
 }
 
 func (c *DirectoryContentsImage) Lock(lockConfig *LockDirectoryContentsImage) error {
 	if lockConfig == nil {
-		return fmt.Errorf("Expected image lock configuration to be non-empty")
+		return fmt.Errorf("expected image lock configuration to be non-empty")
 	}
 	if len(lockConfig.URL) == 0 {
-		return fmt.Errorf("Expected image URL to be non-empty")
+		return fmt.Errorf("expected image URL to be non-empty")
 	}
 	c.URL = lockConfig.URL
 	c.TagSelection = nil // URL is fully resolved already
@@ -385,10 +385,10 @@ func (c *DirectoryContentsImage) Lock(lockConfig *LockDirectoryContentsImage) er
 
 func (c *DirectoryContentsImgpkgBundle) Lock(lockConfig *LockDirectoryContentsImgpkgBundle) error {
 	if lockConfig == nil {
-		return fmt.Errorf("Expected image lock configuration to be non-empty")
+		return fmt.Errorf("expected image lock configuration to be non-empty")
 	}
 	if len(lockConfig.Image) == 0 {
-		return fmt.Errorf("Expected imgpkg bundle Image to be non-empty")
+		return fmt.Errorf("expected imgpkg bundle Image to be non-empty")
 	}
 	c.Image = lockConfig.Image
 	c.TagSelection = nil // URL is fully resolved already
@@ -398,10 +398,10 @@ func (c *DirectoryContentsImgpkgBundle) Lock(lockConfig *LockDirectoryContentsIm
 
 func (c *DirectoryContentsGithubRelease) Lock(lockConfig *LockDirectoryContentsGithubRelease) error {
 	if lockConfig == nil {
-		return fmt.Errorf("Expected github release lock configuration to be non-empty")
+		return fmt.Errorf("expected github release lock configuration to be non-empty")
 	}
 	if len(lockConfig.URL) == 0 {
-		return fmt.Errorf("Expected github release URL to be non-empty")
+		return fmt.Errorf("expected github release URL to be non-empty")
 	}
 	c.URL = lockConfig.URL
 	c.Tag = lockConfig.Tag
@@ -410,10 +410,10 @@ func (c *DirectoryContentsGithubRelease) Lock(lockConfig *LockDirectoryContentsG
 
 func (c *DirectoryContentsHelmChart) Lock(lockConfig *LockDirectoryContentsHelmChart) error {
 	if lockConfig == nil {
-		return fmt.Errorf("Expected helm chart lock configuration to be non-empty")
+		return fmt.Errorf("expected helm chart lock configuration to be non-empty")
 	}
 	if len(lockConfig.Version) == 0 {
-		return fmt.Errorf("Expected helm chart version to be non-empty")
+		return fmt.Errorf("expected helm chart version to be non-empty")
 	}
 	c.Version = lockConfig.Version
 	return nil

--- a/pkg/vendir/config/dockerconfigjson.go
+++ b/pkg/vendir/config/dockerconfigjson.go
@@ -59,12 +59,12 @@ func (s Secret) ToRegistryAuthSecrets() ([]Secret, error) {
 		if len(auth.Password) == 0 && len(auth.Auth) > 0 {
 			decodedAuth, err := base64.StdEncoding.DecodeString(auth.Auth)
 			if err != nil {
-				return nil, fmt.Errorf("Decoding auth field: %s", err)
+				return nil, fmt.Errorf("decoding auth field: %s", err)
 			}
 
 			pieces := strings.SplitN(string(decodedAuth), ":", 2)
 			if len(pieces) != 2 {
-				return nil, fmt.Errorf("Expected auth field to have 'username:password' format, but did not")
+				return nil, fmt.Errorf("expected auth field to have 'username:password' format, but did not")
 			}
 			auth.Username = pieces[0]
 			auth.Password = pieces[1]

--- a/pkg/vendir/config/dockerconfigjson_test.go
+++ b/pkg/vendir/config/dockerconfigjson_test.go
@@ -115,7 +115,7 @@ func TestSecretToRegistryAuthSecretsWithAuthFieldFallback(t *testing.T) {
 		}
 
 		_, err := s1.ToRegistryAuthSecrets()
-		require.EqualError(t, err, "Decoding auth field: illegal base64 data at input byte 4")
+		require.EqualError(t, err, "decoding auth field: illegal base64 data at input byte 4")
 	})
 
 	t.Run("password is empty and auth is invalid due to missing password (errors)", func(t *testing.T) {
@@ -127,7 +127,7 @@ func TestSecretToRegistryAuthSecretsWithAuthFieldFallback(t *testing.T) {
 		}
 
 		_, err := s1.ToRegistryAuthSecrets()
-		require.EqualError(t, err, "Expected auth field to have 'username:password' format, but did not")
+		require.EqualError(t, err, "expected auth field to have 'username:password' format, but did not")
 	})
 
 	t.Run("password is empty, falls back on auth field username+password", func(t *testing.T) {

--- a/pkg/vendir/config/lock_config.go
+++ b/pkg/vendir/config/lock_config.go
@@ -31,7 +31,7 @@ func NewLockConfig() LockConfig {
 func NewLockConfigFromFile(path string) (LockConfig, error) {
 	bs, err := os.ReadFile(path)
 	if err != nil {
-		return LockConfig{}, fmt.Errorf("Reading lock config '%s': %s", path, err)
+		return LockConfig{}, fmt.Errorf("reading lock config '%s': %s", path, err)
 	}
 
 	return NewLockConfigFromBytes(bs)
@@ -42,12 +42,12 @@ func NewLockConfigFromBytes(bs []byte) (LockConfig, error) {
 
 	err := yaml.Unmarshal(bs, &config)
 	if err != nil {
-		return LockConfig{}, fmt.Errorf("Unmarshaling lock config: %s", err)
+		return LockConfig{}, fmt.Errorf("unmarshaling lock config: %s", err)
 	}
 
 	err = config.Validate()
 	if err != nil {
-		return LockConfig{}, fmt.Errorf("Validating lock config: %s", err)
+		return LockConfig{}, fmt.Errorf("validating lock config: %s", err)
 	}
 
 	return config, nil
@@ -56,18 +56,18 @@ func NewLockConfigFromBytes(bs []byte) (LockConfig, error) {
 func (c LockConfig) WriteToFile(path string) error {
 	existingBytes, err := os.ReadFile(path)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("Failed to check existing lock file: %w", err)
+		return fmt.Errorf("failed to check existing lock file: %w", err)
 	}
 
 	bs, err := c.AsBytes()
 	if err != nil {
-		return fmt.Errorf("Marshaling lock config: %s", err)
+		return fmt.Errorf("marshaling lock config: %s", err)
 	}
 
 	if bytes.Compare(existingBytes, bs) != 0 {
 		err = os.WriteFile(path, bs, 0600)
 		if err != nil {
-			return fmt.Errorf("Writing lock config: %s", err)
+			return fmt.Errorf("writing lock config: %s", err)
 		}
 	}
 
@@ -77,7 +77,7 @@ func (c LockConfig) WriteToFile(path string) error {
 func (c LockConfig) AsBytes() ([]byte, error) {
 	bs, err := yaml.Marshal(c)
 	if err != nil {
-		return nil, fmt.Errorf("Marshaling lock config: %s", err)
+		return nil, fmt.Errorf("marshaling lock config: %s", err)
 	}
 
 	return bs, nil
@@ -90,10 +90,10 @@ func (c LockConfig) Validate() error {
 	)
 
 	if c.APIVersion != knownAPIVersion {
-		return fmt.Errorf("Validating apiVersion: Unknown version (known: %s)", knownAPIVersion)
+		return fmt.Errorf("validating apiVersion: Unknown version (known: %s)", knownAPIVersion)
 	}
 	if c.Kind != knownKind {
-		return fmt.Errorf("Validating kind: Unknown kind (known: %s)", knownKind)
+		return fmt.Errorf("validating kind: Unknown kind (known: %s)", knownKind)
 	}
 	return nil
 }
@@ -106,12 +106,12 @@ func (c LockConfig) FindContents(dirPath, conPath string) (LockDirectoryContents
 					return con, nil
 				}
 			}
-			return LockDirectoryContents{}, fmt.Errorf("Expected to find contents '%s' "+
+			return LockDirectoryContents{}, fmt.Errorf("expected to find contents '%s' "+
 				"within directory '%s' in lock config, but did not", conPath, dirPath)
 		}
 	}
 	return LockDirectoryContents{}, fmt.Errorf(
-		"Expected to find directory '%s' within lock config, but did not", dirPath)
+		"expected to find directory '%s' within lock config, but did not", dirPath)
 }
 
 func (c LockConfig) FindDirectory(dirPath string) (LockDirectory, error) {
@@ -121,7 +121,7 @@ func (c LockConfig) FindDirectory(dirPath string) (LockDirectory, error) {
 		}
 	}
 	return LockDirectory{}, fmt.Errorf(
-		"Expected to find directory '%s' within lock config, but did not", dirPath)
+		"expected to find directory '%s' within lock config, but did not", dirPath)
 }
 
 func (c *LockConfig) Merge(other LockConfig) error {

--- a/pkg/vendir/config/lock_config_test.go
+++ b/pkg/vendir/config/lock_config_test.go
@@ -16,13 +16,13 @@ func TestNewLockConfigFromBytes(t *testing.T) {
 	t.Run("invalid yaml returns an error", func(t *testing.T) {
 		invalidYaml := "this !== valid yaml"
 		_, err := config.NewLockConfigFromBytes([]byte(invalidYaml))
-		require.EqualError(t, err, "Unmarshaling lock config: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type config.LockConfig")
+		require.EqualError(t, err, "unmarshaling lock config: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type config.LockConfig")
 	})
 
 	t.Run("valid yaml, but not valid lock config returns an error", func(t *testing.T) {
 		invalidYaml := "apiVersion: not.the.right.apiVersion"
 		_, err := config.NewLockConfigFromBytes([]byte(invalidYaml))
-		require.EqualError(t, err, "Validating lock config: Validating apiVersion: Unknown version (known: vendir.k14s.io/v1alpha1)")
+		require.EqualError(t, err, "validating lock config: validating apiVersion: Unknown version (known: vendir.k14s.io/v1alpha1)")
 	})
 }
 
@@ -41,7 +41,7 @@ func TestValidate(t *testing.T) {
 			Kind:        "LockConfig",
 			Directories: []config.LockDirectory{},
 		}
-		require.EqualError(t, lockConfig.Validate(), "Validating apiVersion: Unknown version (known: vendir.k14s.io/v1alpha1)")
+		require.EqualError(t, lockConfig.Validate(), "validating apiVersion: Unknown version (known: vendir.k14s.io/v1alpha1)")
 	})
 	t.Run("invalid kind returns an error", func(t *testing.T) {
 		lockConfig := config.LockConfig{
@@ -49,7 +49,7 @@ func TestValidate(t *testing.T) {
 			Kind:        "LockedConfig",
 			Directories: []config.LockDirectory{},
 		}
-		require.EqualError(t, lockConfig.Validate(), "Validating kind: Unknown kind (known: LockConfig)")
+		require.EqualError(t, lockConfig.Validate(), "validating kind: Unknown kind (known: LockConfig)")
 	})
 }
 
@@ -98,9 +98,9 @@ func TestWriteToFile(t *testing.T) {
 
 	tempDir, err := os.MkdirTemp("", "test-vendir-write-to-file")
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "lockfile.yml"), lockConfigBytes, 0666))
-	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "lockfile-copy.yml"), lockConfigBytes, 0666))
-	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "other-lockfile.yml"), otherLockFileBytes, 0666))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "lockfile.yml"), lockConfigBytes, 0o666))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "lockfile-copy.yml"), lockConfigBytes, 0o666))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "other-lockfile.yml"), otherLockFileBytes, 0o666))
 
 	t.Run("no prior lock config file will write", func(t *testing.T) {
 		lockFilePath := filepath.Join(tempDir, "new-lockfile.yml")

--- a/pkg/vendir/config/lock_directory.go
+++ b/pkg/vendir/config/lock_directory.go
@@ -72,6 +72,6 @@ func (d LockDirectory) FindContents(conPath string) (LockDirectoryContents, erro
 			return con, nil
 		}
 	}
-	return LockDirectoryContents{}, fmt.Errorf("Expected to find contents '%s' "+
+	return LockDirectoryContents{}, fmt.Errorf("expected to find contents '%s' "+
 		"within directory '%s' in lock config, but did not", conPath, d.Path)
 }

--- a/pkg/vendir/config/resources.go
+++ b/pkg/vendir/config/resources.go
@@ -26,12 +26,12 @@ func parseResources(paths []string, resourceFunc func([]byte) error) error {
 		if path == "-" {
 			bs, err = io.ReadAll(os.Stdin)
 			if err != nil {
-				return fmt.Errorf("Reading config from stdin: %s", err)
+				return fmt.Errorf("reading config from stdin: %s", err)
 			}
 		} else {
 			bs, err = os.ReadFile(path)
 			if err != nil {
-				return fmt.Errorf("Reading config '%s': %s", path, err)
+				return fmt.Errorf("reading config '%s': %s", path, err)
 			}
 		}
 
@@ -43,7 +43,7 @@ func parseResources(paths []string, resourceFunc func([]byte) error) error {
 				break
 			}
 			if err != nil {
-				return fmt.Errorf("Parsing config '%s': %s", path, err)
+				return fmt.Errorf("parsing config '%s': %s", path, err)
 			}
 			// Skip documents that are empty or only contain whitespace
 			if len(bytes.TrimSpace(docBytes)) == 0 {
@@ -51,7 +51,7 @@ func parseResources(paths []string, resourceFunc func([]byte) error) error {
 			}
 			err = resourceFunc(docBytes)
 			if err != nil {
-				return fmt.Errorf("Parsing resource config '%s': %s", path, err)
+				return fmt.Errorf("parsing resource config '%s': %s", path, err)
 			}
 		}
 	}

--- a/pkg/vendir/directory/directory.go
+++ b/pkg/vendir/directory/directory.go
@@ -98,7 +98,7 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 			// copy previously fetched contents to staging dir
 			err = dircopy.Copy(filepath.Join(d.opts.Path, contents.Path), stagingDstPath)
 			if err != nil {
-				return lockConfig, fmt.Errorf("Lazy content missing. Run sync with --lazy=false to fix. '%s': %s", d.opts.Path, err)
+				return lockConfig, fmt.Errorf("lazy content missing. Run sync with --lazy=false to fix. '%s': %s", d.opts.Path, err)
 			}
 			continue
 		}
@@ -114,7 +114,7 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 			lock, err := gitSync.Sync(stagingDstPath, stagingDir.TempArea())
 			if err != nil {
-				return lockConfig, fmt.Errorf("Syncing directory '%s' with git contents: %s", contents.Path, err)
+				return lockConfig, fmt.Errorf("syncing directory '%s' with git contents: %s", contents.Path, err)
 			}
 			lockDirContents.Git = &lock
 
@@ -125,7 +125,7 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 			lock, err := hgSync.Sync(stagingDstPath, stagingDir.TempArea())
 			if err != nil {
-				return lockConfig, fmt.Errorf("Syncing directory '%s' with hg contents: %s", contents.Path, err)
+				return lockConfig, fmt.Errorf("syncing directory '%s' with hg contents: %s", contents.Path, err)
 			}
 
 			lockDirContents.Hg = &lock
@@ -135,7 +135,7 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 			lock, err := ctlhttp.NewSync(*contents.HTTP, syncOpts.RefFetcher).Sync(stagingDstPath, stagingDir.TempArea())
 			if err != nil {
-				return lockConfig, fmt.Errorf("Syncing directory '%s' with HTTP contents: %s", contents.Path, err)
+				return lockConfig, fmt.Errorf("syncing directory '%s' with HTTP contents: %s", contents.Path, err)
 			}
 
 			lockDirContents.HTTP = &lock
@@ -147,7 +147,7 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 			lock, err := imageSync.Sync(stagingDstPath)
 			if err != nil {
-				return lockConfig, fmt.Errorf("Syncing directory '%s' with image contents: %s", contents.Path, err)
+				return lockConfig, fmt.Errorf("syncing directory '%s' with image contents: %s", contents.Path, err)
 			}
 
 			lockDirContents.Image = &lock
@@ -159,7 +159,7 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 			lock, err := imgpkgBundleSync.Sync(stagingDstPath)
 			if err != nil {
-				return lockConfig, fmt.Errorf("Syncing directory '%s' with imgpkgBundle contents: %s", contents.Path, err)
+				return lockConfig, fmt.Errorf("syncing directory '%s' with imgpkgBundle contents: %s", contents.Path, err)
 			}
 
 			lockDirContents.ImgpkgBundle = &lock
@@ -175,7 +175,7 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 			lock, err := sync.Sync(stagingDstPath, stagingDir.TempArea())
 			if err != nil {
-				return lockConfig, fmt.Errorf("Syncing directory '%s' with github release contents: %s", contents.Path, err)
+				return lockConfig, fmt.Errorf("syncing directory '%s' with github release contents: %s", contents.Path, err)
 			}
 
 			lockDirContents.GithubRelease = &lock
@@ -188,7 +188,7 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 			lock, err := helmChartSync.Sync(stagingDstPath, stagingDir.TempArea())
 			if err != nil {
-				return lockConfig, fmt.Errorf("Syncing directory '%s' with helm chart contents: %s", contents.Path, err)
+				return lockConfig, fmt.Errorf("syncing directory '%s' with helm chart contents: %s", contents.Path, err)
 			}
 			lockDirContents.HelmChart = &lock
 
@@ -199,7 +199,7 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 			err := os.Rename(srcPath, stagingDstPath)
 			if err != nil {
-				return lockConfig, fmt.Errorf("Moving directory '%s' to staging dir: %s", srcPath, err)
+				return lockConfig, fmt.Errorf("moving directory '%s' to staging dir: %s", srcPath, err)
 			}
 
 			lockDirContents.Manual = &ctlconf.LockDirectoryContentsManual{}
@@ -211,7 +211,7 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 			err := dircopy.Copy(contents.Directory.Path, stagingDstPath)
 			if err != nil {
-				return lockConfig, fmt.Errorf("Copying another directory contents into directory '%s': %s", contents.Path, err)
+				return lockConfig, fmt.Errorf("copying another directory contents into directory '%s': %s", contents.Path, err)
 			}
 
 			lockDirContents.Directory = &ctlconf.LockDirectoryContentsDirectory{}
@@ -221,33 +221,33 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 			lock, err := ctlinl.NewSync(*contents.Inline, syncOpts.RefFetcher).Sync(stagingDstPath)
 			if err != nil {
-				return lockConfig, fmt.Errorf("Syncing directory '%s' with inline contents: %s", contents.Path, err)
+				return lockConfig, fmt.Errorf("syncing directory '%s' with inline contents: %s", contents.Path, err)
 			}
 
 			lockDirContents.Inline = &lock
 
 		default:
-			return lockConfig, fmt.Errorf("Unknown contents type for directory '%s'", contents.Path)
+			return lockConfig, fmt.Errorf("unknown contents type for directory '%s'", contents.Path)
 		}
 
 		if !skipFileFilter {
 			err = FileFilter{contents}.Apply(stagingDstPath)
 			if err != nil {
-				return lockConfig, fmt.Errorf("Filtering paths in directory '%s': %s", contents.Path, err)
+				return lockConfig, fmt.Errorf("filtering paths in directory '%s': %s", contents.Path, err)
 			}
 		}
 
 		if !skipNewRootPath && len(contents.NewRootPath) > 0 {
 			err = NewSubPath(contents.NewRootPath).Extract(stagingDstPath, stagingDstPath, stagingDir.TempArea())
 			if err != nil {
-				return lockConfig, fmt.Errorf("Changing to new root path '%s': %s", contents.Path, err)
+				return lockConfig, fmt.Errorf("changing to new root path '%s': %s", contents.Path, err)
 			}
 		}
 
 		// Copy files from current source if values are supposed to be ignored
 		err = stagingDir.CopyExistingFiles(d.opts.Path, stagingDstPath, contents.IgnorePaths)
 		if err != nil {
-			return lockConfig, fmt.Errorf("Copying existing content to staging '%s': %s", d.opts.Path, err)
+			return lockConfig, fmt.Errorf("copying existing content to staging '%s': %s", d.opts.Path, err)
 		}
 
 		// after everything else is done, ensure the inner dir's access perms are set

--- a/pkg/vendir/directory/file_filter.go
+++ b/pkg/vendir/directory/file_filter.go
@@ -62,7 +62,7 @@ func (d FileFilter) Apply(dirPath string) error {
 		if !matched {
 			err := os.RemoveAll(path)
 			if err != nil {
-				return fmt.Errorf("Deleting file %s: %s", path, err)
+				return fmt.Errorf("deleting file %s: %s", path, err)
 			}
 		}
 
@@ -120,7 +120,7 @@ func (d FileFilter) deleteEmptyDirs(dirPath string, topLevel bool) (bool, error)
 
 	if !hasFiles {
 		if topLevel {
-			return false, fmt.Errorf("Expected to find at least one file within directory")
+			return false, fmt.Errorf("expected to find at least one file within directory")
 		}
 		// not RemoveAll to double check directory is empty
 		return false, os.Remove(dirPath)

--- a/pkg/vendir/directory/staging_dir.go
+++ b/pkg/vendir/directory/staging_dir.go
@@ -35,12 +35,12 @@ func NewStagingDir() (StagingDir, error) {
 func (d StagingDir) Prepare() error {
 	err := os.MkdirAll(d.stagingDir, 0700)
 	if err != nil {
-		return fmt.Errorf("Creating staging dir '%s': %s", d.stagingDir, err)
+		return fmt.Errorf("creating staging dir '%s': %s", d.stagingDir, err)
 	}
 
 	err = os.MkdirAll(d.incomingDir, 0700)
 	if err != nil {
-		return fmt.Errorf("Creating incoming dir '%s': %s", d.incomingDir, err)
+		return fmt.Errorf("creating incoming dir '%s': %s", d.incomingDir, err)
 	}
 
 	return nil
@@ -52,7 +52,7 @@ func (d StagingDir) NewChild(path string) (string, error) {
 
 	err := os.MkdirAll(childPathParent, 0700)
 	if err != nil {
-		return "", fmt.Errorf("Creating directory '%s': %s", childPathParent, err)
+		return "", fmt.Errorf("creating directory '%s': %s", childPathParent, err)
 	}
 
 	return childPath, nil
@@ -98,13 +98,13 @@ func (d StagingDir) CopyExistingFiles(rootDir string, stagingPath string, ignore
 		stagingDir := filepath.Dir(stagingPath)
 		err = os.MkdirAll(stagingDir, 0700)
 		if err != nil {
-			return fmt.Errorf("Unable to create staging directory '%s': %s", stagingDir, err)
+			return fmt.Errorf("unable to create staging directory '%s': %s", stagingDir, err)
 		}
 
 		// Move the file to the staging directory
 		err = copyFile(path, stagingPath)
 		if err != nil {
-			return fmt.Errorf("Moving source file '%s' to staging location '%s': %s", path, stagingPath, err)
+			return fmt.Errorf("moving source file '%s' to staging location '%s': %s", path, stagingPath, err)
 		}
 		return nil
 	})
@@ -138,7 +138,7 @@ func (d StagingDir) Replace(path string) error {
 
 	err = os.Rename(d.stagingDir, path)
 	if err != nil {
-		return fmt.Errorf("Moving staging directory '%s' to final location '%s': %s", d.stagingDir, path, err)
+		return fmt.Errorf("moving staging directory '%s' to final location '%s': %s", d.stagingDir, path, err)
 	}
 
 	return nil
@@ -153,7 +153,7 @@ func (d StagingDir) PartialRepace(contentPath string, directoryPath string) erro
 
 	err = os.Rename(filepath.Join(d.stagingDir, contentPath), directoryPath)
 	if err != nil {
-		return fmt.Errorf("Moving staging directory '%s' to final location '%s': %s", d.stagingDir, directoryPath, err)
+		return fmt.Errorf("moving staging directory '%s' to final location '%s': %s", d.stagingDir, directoryPath, err)
 	}
 
 	return nil
@@ -162,7 +162,7 @@ func (d StagingDir) PartialRepace(contentPath string, directoryPath string) erro
 func (d StagingDir) prepareOutputDirectory(directoryPath string) error {
 	err := os.RemoveAll(directoryPath)
 	if err != nil {
-		return fmt.Errorf("Deleting dir %s: %s", directoryPath, err)
+		return fmt.Errorf("deleting dir %s: %s", directoryPath, err)
 	}
 
 	// Clean to avoid getting 'out/in/' from 'out/in/' instead of just 'out'
@@ -170,7 +170,7 @@ func (d StagingDir) prepareOutputDirectory(directoryPath string) error {
 
 	err = os.MkdirAll(parentPath, 0700)
 	if err != nil {
-		return fmt.Errorf("Creating final location parent dir %s: %s", parentPath, err)
+		return fmt.Errorf("creating final location parent dir %s: %s", parentPath, err)
 	}
 	return nil
 }
@@ -186,7 +186,7 @@ func (d StagingDir) CleanUp() error {
 func (d StagingDir) cleanUpAll() error {
 	err := os.RemoveAll(d.rootDir)
 	if err != nil {
-		return fmt.Errorf("Deleting tmp dir '%s': %s", d.rootDir, err)
+		return fmt.Errorf("deleting tmp dir '%s': %s", d.rootDir, err)
 	}
 	return nil
 }
@@ -202,12 +202,12 @@ func (d StagingTempArea) NewTempDir(name string) (string, error) {
 
 	absTmpDir, err := filepath.Abs(tmpDir)
 	if err != nil {
-		return "", fmt.Errorf("Abs path '%s': %s", tmpDir, err)
+		return "", fmt.Errorf("abs path '%s': %s", tmpDir, err)
 	}
 
 	err = os.Mkdir(absTmpDir, 0700)
 	if err != nil {
-		return "", fmt.Errorf("Creating incoming dir '%s' for %s: %s", absTmpDir, name, err)
+		return "", fmt.Errorf("creating incoming dir '%s' for %s: %s", absTmpDir, name, err)
 	}
 
 	return absTmpDir, nil
@@ -220,7 +220,7 @@ func (d StagingTempArea) NewTempFile(pattern string) (*os.File, error) {
 func copyFile(src, dst string) error {
 	sourceFileStat, err := os.Stat(src)
 	if err != nil {
-		return fmt.Errorf("Unable to read file info: %s", src)
+		return fmt.Errorf("unable to read file info: %s", src)
 	}
 
 	if !sourceFileStat.Mode().IsRegular() {
@@ -229,20 +229,20 @@ func copyFile(src, dst string) error {
 
 	srcFile, err := os.Open(src)
 	if err != nil {
-		return fmt.Errorf("Unable to open file: %s", src)
+		return fmt.Errorf("unable to open file: %s", src)
 	}
 	defer srcFile.Close()
 
 	dstFile, err := os.Create(dst)
 	if err != nil {
-		return fmt.Errorf("Unable to create destination file: %s", dst)
+		return fmt.Errorf("unable to create destination file: %s", dst)
 	}
 
 	defer dstFile.Close()
 
 	_, err = io.Copy(dstFile, srcFile)
 	if err != nil {
-		return fmt.Errorf("Copying into dst file: %s", err)
+		return fmt.Errorf("copying into dst file: %s", err)
 	}
 
 	return nil

--- a/pkg/vendir/directory/sub_path.go
+++ b/pkg/vendir/directory/sub_path.go
@@ -67,7 +67,7 @@ func (s SubPath) checkDirExists(path, srcPath string) error {
 		}
 	}
 
-	return fmt.Errorf("Expected directory '%s' (subpath) to exist%s", s.subPath, hintMsg)
+	return fmt.Errorf("expected directory '%s' (subpath) to exist%s", s.subPath, hintMsg)
 }
 
 func (s SubPath) findMissingDir(srcPath string) (string, error) {

--- a/pkg/vendir/directory/symlink.go
+++ b/pkg/vendir/directory/symlink.go
@@ -22,7 +22,7 @@ func ValidateSymlinks(path string) error {
 		if info.Type()&os.ModeSymlink == os.ModeSymlink {
 			resolvedPath, err := filepath.EvalSymlinks(path)
 			if err != nil {
-				return fmt.Errorf("Unable to resolve symlink: %w", err)
+				return fmt.Errorf("unable to resolve symlink: %w", err)
 			}
 			absPath, err := filepath.Abs(resolvedPath)
 			if err != nil {
@@ -31,11 +31,11 @@ func ValidateSymlinks(path string) error {
 			pathSegments := strings.Split(absPath, string(os.PathSeparator))
 
 			if len(rootSegments) > len(pathSegments) {
-				return fmt.Errorf("Invalid symlink found to outside parent directory: %q", absPath)
+				return fmt.Errorf("invalid symlink found to outside parent directory: %q", absPath)
 			}
 			for i, segment := range rootSegments {
 				if pathSegments[i] != segment {
-					return fmt.Errorf("Invalid symlink found to outside parent directory: %q", absPath)
+					return fmt.Errorf("invalid symlink found to outside parent directory: %q", absPath)
 				}
 			}
 		}

--- a/pkg/vendir/fetch/archive.go
+++ b/pkg/vendir/fetch/archive.go
@@ -51,19 +51,19 @@ func (t Archive) writeIntoFile(srcFile io.Reader, dstPath, additionalPath string
 
 	err := os.MkdirAll(filepath.Dir(dstFilePath), 0700)
 	if err != nil {
-		return fmt.Errorf("Making intermediate dir: %s", err)
+		return fmt.Errorf("making intermediate dir: %s", err)
 	}
 
 	dstFile, err := os.Create(dstFilePath)
 	if err != nil {
-		return fmt.Errorf("Creating dst file: %s", err)
+		return fmt.Errorf("creating dst file: %s", err)
 	}
 
 	defer dstFile.Close()
 
 	_, err = io.Copy(dstFile, srcFile)
 	if err != nil {
-		return fmt.Errorf("Copying into dst file: %s", err)
+		return fmt.Errorf("copying into dst file: %s", err)
 	}
 
 	return nil
@@ -77,7 +77,7 @@ func (t Archive) writeIntoFileAndClose(srcFile io.ReadCloser, dstPath, additiona
 func (t Archive) tryZip(path, dstPath string) (bool, error) {
 	zipArchive, err := zip.OpenReader(path)
 	if err != nil {
-		return false, fmt.Errorf("Opening zip archive: %s", err)
+		return false, fmt.Errorf("opening zip archive: %s", err)
 	}
 
 	defer zipArchive.Close()
@@ -90,7 +90,7 @@ func (t Archive) tryZip(path, dstPath string) (bool, error) {
 
 		srcZipFile, err := f.Open()
 		if err != nil {
-			return true, fmt.Errorf("Opening zip file: %s", err)
+			return true, fmt.Errorf("opening zip file: %s", err)
 		}
 
 		err = t.writeIntoFileAndClose(srcZipFile, dstPath, f.Name)
@@ -113,7 +113,7 @@ func (t Archive) tryTar(path, dstPath string) (bool, error) {
 func (t Archive) tryTarWithGzip(path, dstPath string, gzipped bool) (bool, error) {
 	plainFile, err := os.Open(path)
 	if err != nil {
-		return false, fmt.Errorf("Opening archive: %s", err)
+		return false, fmt.Errorf("opening archive: %s", err)
 	}
 
 	defer plainFile.Close()
@@ -123,7 +123,7 @@ func (t Archive) tryTarWithGzip(path, dstPath string, gzipped bool) (bool, error
 	if gzipped {
 		gzipFile, err := gzip.NewReader(plainFile)
 		if err != nil {
-			return false, fmt.Errorf("Opening gzip archive: %s", err)
+			return false, fmt.Errorf("opening gzip archive: %s", err)
 		}
 		fileReader = gzipFile
 	} else {
@@ -139,7 +139,7 @@ func (t Archive) tryTarWithGzip(path, dstPath string, gzipped bool) (bool, error
 			if err == io.EOF {
 				break
 			}
-			return readEntries, fmt.Errorf("Reading next tar header: %s", err)
+			return readEntries, fmt.Errorf("reading next tar header: %s", err)
 		}
 
 		readEntries = true
@@ -159,7 +159,7 @@ func (t Archive) tryTarWithGzip(path, dstPath string, gzipped bool) (bool, error
 			continue
 
 		default:
-			return false, fmt.Errorf("Unknown file '%s' (%d)", header.Name, header.Typeflag)
+			return false, fmt.Errorf("unknown file '%s' (%d)", header.Name, header.Typeflag)
 		}
 	}
 
@@ -169,7 +169,7 @@ func (t Archive) tryTarWithGzip(path, dstPath string, gzipped bool) (bool, error
 func (t Archive) tryPlain(path, dstPath string) error {
 	parsedURL, err := gourl.Parse(t.fallbackOnPlainURL)
 	if err != nil {
-		return fmt.Errorf("Parsing URL: %s", err)
+		return fmt.Errorf("parsing URL: %s", err)
 	}
 
 	pathSegs := strings.Split(parsedURL.Path, "/")
@@ -181,7 +181,7 @@ func (t Archive) tryPlain(path, dstPath string) error {
 
 	srcFile, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("Opening file %s: %s", path, err)
+		return fmt.Errorf("opening file %s: %s", path, err)
 	}
 
 	// Cannot just move since it may be on a different device

--- a/pkg/vendir/fetch/cache/cache.go
+++ b/pkg/vendir/fetch/cache/cache.go
@@ -37,7 +37,7 @@ func NewCache(cacheFolder string, maxContentCacheableSize string) (Cache, error)
 	}
 	q, err := resources.ParseQuantity(maxContentCacheableSize)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to process maximum amount allowed to cache: %s", err)
+		return nil, fmt.Errorf("unable to process maximum amount allowed to cache: %s", err)
 	}
 	return &FolderCache{folder: cacheFolder, maxSize: q}, nil
 }
@@ -66,7 +66,7 @@ func (c FolderCache) Has(artifactType string, id string) (string, bool) {
 func (c FolderCache) Save(artifactType string, id string, src string) error {
 	contentSize, err := c.dirSize(src)
 	if err != nil {
-		return fmt.Errorf("Unable to find size of folder to be cached: %s", err)
+		return fmt.Errorf("unable to find size of folder to be cached: %s", err)
 	}
 
 	// When the content size is bigger than the maximum allowed amount it should not try to save into the cache
@@ -90,7 +90,7 @@ func (c FolderCache) Save(artifactType string, id string, src string) error {
 func (c FolderCache) CopyFrom(artifactType string, id string, dst string) error {
 	src, hit := c.Has(artifactType, id)
 	if !hit {
-		return fmt.Errorf("There is no cache entry for '%s'", id)
+		return fmt.Errorf("there is no cache entry for '%s'", id)
 	}
 
 	return c.copyFolder(src, dst)

--- a/pkg/vendir/fetch/git/git.go
+++ b/pkg/vendir/fetch/git/git.go
@@ -49,7 +49,7 @@ type GitInfo struct {
 
 func (t *Git) Retrieve(dstPath string, tempArea ctlfetch.TempArea, bundle string) (GitInfo, error) {
 	if len(t.opts.URL) == 0 {
-		return GitInfo{}, fmt.Errorf("Expected non-empty URL")
+		return GitInfo{}, fmt.Errorf("expected non-empty URL")
 	}
 
 	err := t.fetch(dstPath, tempArea, bundle)
@@ -105,7 +105,7 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 			// Ensure the private key ends with a newline character, as git requires it to work. (https://github.com/carvel-dev/vendir/issues/350)
 			err = os.WriteFile(path, []byte(*authOpts.PrivateKey+"\n"), 0600)
 			if err != nil {
-				return fmt.Errorf("Writing private key: %s", err)
+				return fmt.Errorf("writing private key: %s", err)
 			}
 
 			sshCmd = append(sshCmd, "-i", path, "-o", "IdentitiesOnly=yes")
@@ -116,7 +116,7 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 
 			err = os.WriteFile(path, []byte(*authOpts.KnownHosts), 0600)
 			if err != nil {
-				return fmt.Errorf("Writing known hosts: %s", err)
+				return fmt.Errorf("writing known hosts: %s", err)
 			}
 
 			sshCmd = append(sshCmd, "-o", "StrictHostKeyChecking=yes", "-o", "UserKnownHostsFile="+path)
@@ -144,7 +144,7 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 
 	if authOpts.Username != nil && authOpts.Password != nil {
 		if !strings.HasPrefix(gitURL, "https://") {
-			return fmt.Errorf("Username/password authentication is only supported for https remotes")
+			return fmt.Errorf("username/password authentication is only supported for https remotes")
 		}
 
 		if t.opts.ForceHTTPBasicAuth {
@@ -153,7 +153,7 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 		} else {
 			gitCredsURL, err := url.Parse(gitURL)
 			if err != nil {
-				return fmt.Errorf("Parsing git remote url: %s", err)
+				return fmt.Errorf("parsing git remote url: %s", err)
 			}
 
 			gitCredsURL.User = url.UserPassword(*authOpts.Username, *authOpts.Password)
@@ -161,7 +161,7 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 
 			err = os.WriteFile(gitCredsPath, []byte(gitCredsURL.String()+"\n"), 0600)
 			if err != nil {
-				return fmt.Errorf("Writing %s: %s", gitCredsPath, err)
+				return fmt.Errorf("writing %s: %s", gitCredsPath, err)
 			}
 		}
 	}
@@ -232,7 +232,7 @@ func (t *Git) resolveRef(dstPath string) (string, error) {
 		return ctlver.HighestConstrainedVersion(tags, *t.opts.RefSelection)
 
 	default:
-		return "", fmt.Errorf("Expected either ref or ref selection to be specified")
+		return "", fmt.Errorf("expected either ref or ref selection to be specified")
 	}
 }
 
@@ -277,7 +277,7 @@ func (r *runner) Run(args []string, env []string, dstPath string) (string, strin
 
 	err := cmd.Run()
 	if err != nil {
-		return "", "", fmt.Errorf("Git %s: %s (stderr: %s)", args, err, stderrBs.String())
+		return "", "", fmt.Errorf("git %s: %s (stderr: %s)", args, err, stderrBs.String())
 	}
 
 	return stdoutBs.String(), stderrBs.String(), nil
@@ -318,7 +318,7 @@ func (t *Git) getAuthOpts() (gitAuthOpts, error) {
 				password := string(val)
 				opts.Password = &password
 			default:
-				return opts, fmt.Errorf("Unknown secret field '%s' in secret '%s'", name, t.opts.SecretRef.Name)
+				return opts, fmt.Errorf("unknown secret field '%s' in secret '%s'", name, t.opts.SecretRef.Name)
 			}
 		}
 	}

--- a/pkg/vendir/fetch/git/git_test.go
+++ b/pkg/vendir/fetch/git/git_test.go
@@ -63,7 +63,7 @@ func TestGit_Retrieve(t *testing.T) {
 			ForceHTTPBasicAuth: true,
 		}, os.Stdout, secretFetcher, runner)
 		_, err := gitRetriever.Retrieve("", &tmpFolder{t}, "")
-		require.ErrorContains(t, err, "Username/password authentication is only supported for https remotes")
+		require.ErrorContains(t, err, "username/password authentication is only supported for https remotes")
 	})
 }
 

--- a/pkg/vendir/fetch/git/line_section_reader.go
+++ b/pkg/vendir/fetch/git/line_section_reader.go
@@ -22,14 +22,14 @@ func (r lineSectionReader) Read(contents string, required bool) (string, string,
 		switch {
 		case line == r.StartLine:
 			if opened {
-				return "", "", fmt.Errorf("Expected section to be closed before opening")
+				return "", "", fmt.Errorf("expected section to be closed before opening")
 			}
 			opened = true
 			sectionLines = append(sectionLines, line)
 
 		case line == r.EndLine:
 			if !opened {
-				return "", "", fmt.Errorf("Expected section to be opened before closing")
+				return "", "", fmt.Errorf("expected section to be opened before closing")
 			}
 			closed = true
 			sectionLines = append(sectionLines, line)
@@ -43,10 +43,10 @@ func (r lineSectionReader) Read(contents string, required bool) (string, string,
 	}
 
 	if opened && !closed {
-		return "", "", fmt.Errorf("Expected section to be closed before ending")
+		return "", "", fmt.Errorf("expected section to be closed before ending")
 	}
 	if required && !opened {
-		return "", "", fmt.Errorf("Expected to find section '%s', but did not", r.Description)
+		return "", "", fmt.Errorf("expected to find section '%s', but did not", r.Description)
 	}
 
 	return strings.Join(outsideLines, "\n"), strings.Join(sectionLines, "\n"), nil

--- a/pkg/vendir/fetch/git/sync.go
+++ b/pkg/vendir/fetch/git/sync.go
@@ -63,7 +63,7 @@ func (d Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDire
 
 	info, err := git.Retrieve(incomingTmpPath, tempArea, bundle)
 	if err != nil {
-		return gitLockConf, fmt.Errorf("Fetching git repository: %s", err)
+		return gitLockConf, fmt.Errorf("fetching git repository: %s", err)
 	}
 
 	gitLockConf.SHA = info.SHA
@@ -101,12 +101,12 @@ func (d Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDire
 
 	err = os.RemoveAll(dstPath)
 	if err != nil {
-		return gitLockConf, fmt.Errorf("Deleting dir %s: %s", dstPath, err)
+		return gitLockConf, fmt.Errorf("deleting dir %s: %s", dstPath, err)
 	}
 
 	err = os.Rename(incomingTmpPath, dstPath)
 	if err != nil {
-		return gitLockConf, fmt.Errorf("Moving directory '%s' to staging dir: %s", incomingTmpPath, err)
+		return gitLockConf, fmt.Errorf("moving directory '%s' to staging dir: %s", incomingTmpPath, err)
 	}
 
 	return gitLockConf, nil

--- a/pkg/vendir/fetch/git/verification.go
+++ b/pkg/vendir/fetch/git/verification.go
@@ -37,11 +37,11 @@ func (v Verification) Verify(ref string) error {
 
 	publicKeys, err := oarmor.ReadArmoredKeys(publicKeysStr)
 	if err != nil {
-		return fmt.Errorf("Reading armored key ring: %s", err)
+		return fmt.Errorf("reading armored key ring: %s", err)
 	}
 
 	if len(publicKeys) == 0 {
-		return fmt.Errorf("Expected at least one public key, but found 0")
+		return fmt.Errorf("expected at least one public key, but found 0")
 	}
 
 	signedObj, err := v.readObject(ref)
@@ -58,7 +58,7 @@ func (v Verification) Verify(ref string) error {
 		if strings.Contains(err.Error(), "signature made by unknown entity") {
 			hintMsg = " (hint: provided public key does not match signature)"
 		}
-		return fmt.Errorf("Checking signature: %s%s", err, hintMsg)
+		return fmt.Errorf("checking signature: %s%s", err, hintMsg)
 	}
 
 	return nil
@@ -82,7 +82,7 @@ func (v Verification) readObject(ref string) (signedObj, error) {
 		return v.extractCommitSignature(out)
 	}
 
-	return signedObj{}, fmt.Errorf("Reading git object for '%s': %s", ref, err)
+	return signedObj{}, fmt.Errorf("reading git object for '%s': %s", ref, err)
 }
 
 func (v Verification) extractCommitSignature(obj string) (signedObj, error) {
@@ -96,7 +96,7 @@ func (v Verification) extractCommitSignature(obj string) (signedObj, error) {
 
 	nonSig, sig, err := sectionReader.Read(obj, true)
 	if err != nil {
-		return signedObj{}, fmt.Errorf("Expected to find commit signature: %s", err)
+		return signedObj{}, fmt.Errorf("expected to find commit signature: %s", err)
 	}
 
 	sig = strings.TrimPrefix(sig, "gpgsig ")    // header
@@ -116,7 +116,7 @@ func (v Verification) extractTagSignature(obj string) (signedObj, error) {
 
 	nonSig, sig, err := sectionReader.Read(obj, true)
 	if err != nil {
-		return signedObj{}, fmt.Errorf("Expected to find tag signature: %s", err)
+		return signedObj{}, fmt.Errorf("expected to find tag signature: %s", err)
 	}
 
 	return signedObj{Contents: nonSig, Signature: sig}, nil
@@ -132,7 +132,7 @@ func (v Verification) run(args []string) (string, string, error) {
 
 	err := cmd.Run()
 	if err != nil {
-		return "", "", fmt.Errorf("Git %s: %s (stderr: %s)", args, err, stderrBs.String())
+		return "", "", fmt.Errorf("git %s: %s (stderr: %s)", args, err, stderrBs.String())
 	}
 
 	return stdoutBs.String(), stderrBs.String(), nil

--- a/pkg/vendir/fetch/githubrelease/release_notes_checksums.go
+++ b/pkg/vendir/fetch/githubrelease/release_notes_checksums.go
@@ -32,7 +32,7 @@ func (ReleaseNotesChecksums) Find(assets []ReleaseAssetAPI, body string) (map[st
 		}
 
 		if !found {
-			return results, fmt.Errorf("Expected to find sha256 checksum for file '%s'", asset.Name)
+			return results, fmt.Errorf("expected to find sha256 checksum for file '%s'", asset.Name)
 		}
 	}
 

--- a/pkg/vendir/fetch/githubrelease/sync.go
+++ b/pkg/vendir/fetch/githubrelease/sync.go
@@ -36,7 +36,7 @@ func NewSync(opts ctlconf.DirectoryContentsGithubRelease,
 	sync := Sync{opts, defaultAPIToken, refFetcher, nil}
 	accessToken, err := sync.authToken()
 	if err != nil {
-		return Sync{}, fmt.Errorf("Getting auth token: %s", err.Error())
+		return Sync{}, fmt.Errorf("getting auth token: %s", err.Error())
 	}
 	if accessToken == "" {
 		sync.client = github.NewClient(nil)
@@ -68,7 +68,7 @@ func (d Sync) Desc() (string, error) {
 	case d.opts.Latest:
 		desc = d.opts.Slug + "@latest"
 	default:
-		return "", fmt.Errorf("Expected to have non-empty tag, tagSelection, latest or url")
+		return "", fmt.Errorf("expected to have non-empty tag, tagSelection, latest or url")
 	}
 	return desc, nil
 }
@@ -90,7 +90,7 @@ func (d Sync) url() (string, error) {
 	case d.opts.Latest:
 		url += "/latest"
 	default:
-		return "", fmt.Errorf("Expected to have non-empty tag, tagSelection, latest or url")
+		return "", fmt.Errorf("expected to have non-empty tag, tagSelection, latest or url")
 	}
 	return url, nil
 }
@@ -112,13 +112,13 @@ func (d Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDire
 
 	releaseAPI, err := d.downloadRelease(authToken)
 	if err != nil {
-		return lockConf, fmt.Errorf("Downloading release info: %s", err)
+		return lockConf, fmt.Errorf("downloading release info: %s", err)
 	}
 
 	if d.opts.HTTP != nil {
 		_, err = d.syncHTTP(incomingTmpPath, tempArea, releaseAPI)
 		if err != nil {
-			return lockConf, fmt.Errorf("Fetching http asset: %s", err)
+			return lockConf, fmt.Errorf("fetching http asset: %s", err)
 		}
 	} else {
 		fileChecksums := map[string]string{}
@@ -127,7 +127,7 @@ func (d Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDire
 		for _, asset := range releaseAPI.Assets {
 			matched, err := d.matchesAssetName(asset.Name)
 			if err != nil {
-				return lockConf, fmt.Errorf("Matching asset name '%s': %s", asset.Name, err)
+				return lockConf, fmt.Errorf("matching asset name '%s': %s", asset.Name, err)
 			}
 			if matched {
 				matchedAssets = append(matchedAssets, asset)
@@ -140,7 +140,7 @@ func (d Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDire
 			if !d.opts.DisableAutoChecksumValidation {
 				fileChecksums, err = ReleaseNotesChecksums{}.Find(matchedAssets, releaseAPI.Body)
 				if err != nil {
-					return lockConf, fmt.Errorf("Finding checksums in release notes: %s", err)
+					return lockConf, fmt.Errorf("finding checksums in release notes: %s", err)
 				}
 			}
 		}
@@ -150,18 +150,18 @@ func (d Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDire
 
 			err = d.downloadFile(asset.URL, path, authToken)
 			if err != nil {
-				return lockConf, fmt.Errorf("Downloading asset '%s': %s", asset.Name, err)
+				return lockConf, fmt.Errorf("downloading asset '%s': %s", asset.Name, err)
 			}
 
 			err = d.checkFileSize(path, asset.Size)
 			if err != nil {
-				return lockConf, fmt.Errorf("Checking asset '%s' size: %s", asset.Name, err)
+				return lockConf, fmt.Errorf("checking asset '%s' size: %s", asset.Name, err)
 			}
 
 			if len(fileChecksums) > 0 {
 				err = d.checkFileChecksum(path, fileChecksums[asset.Name])
 				if err != nil {
-					return lockConf, fmt.Errorf("Checking asset '%s' checksum: %s", asset.Name, err)
+					return lockConf, fmt.Errorf("checking asset '%s' checksum: %s", asset.Name, err)
 				}
 			}
 		}
@@ -178,17 +178,17 @@ func (d Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDire
 		_, err = os.Stat(filepath.Join(incomingTmpPath, d.opts.UnpackArchive.Path))
 		if err != nil {
 			if os.IsNotExist(err) {
-				return lockConf, fmt.Errorf("Unpacking archive '%s' is not part of the github release", d.opts.UnpackArchive.Path)
+				return lockConf, fmt.Errorf("unpacking archive '%s' is not part of the github release", d.opts.UnpackArchive.Path)
 			}
 			return lockConf, err
 		}
 
 		final, err := ctlfetch.NewArchive(filepath.Join(incomingTmpPath, d.opts.UnpackArchive.Path), false, "").Unpack(newIncomingTmpPath)
 		if err != nil {
-			return lockConf, fmt.Errorf("Unpacking archive '%s': %s", d.opts.UnpackArchive.Path, err)
+			return lockConf, fmt.Errorf("unpacking archive '%s': %s", d.opts.UnpackArchive.Path, err)
 		}
 		if !final {
-			return lockConf, fmt.Errorf("Expected known archive type (zip, tgz, tar)")
+			return lockConf, fmt.Errorf("expected known archive type (zip, tgz, tar)")
 		}
 
 		incomingTmpPath = newIncomingTmpPath
@@ -196,12 +196,12 @@ func (d Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDire
 
 	err = os.RemoveAll(dstPath)
 	if err != nil {
-		return lockConf, fmt.Errorf("Deleting dir %s: %s", dstPath, err)
+		return lockConf, fmt.Errorf("deleting dir %s: %s", dstPath, err)
 	}
 
 	err = os.Rename(incomingTmpPath, dstPath)
 	if err != nil {
-		return lockConf, fmt.Errorf("Moving directory '%s' to staging dir: %s", incomingTmpPath, err)
+		return lockConf, fmt.Errorf("moving directory '%s' to staging dir: %s", incomingTmpPath, err)
 	}
 
 	lockConf.URL = releaseAPI.URL
@@ -252,13 +252,13 @@ func (d Sync) fetchTagSelection() (string, error) {
 					errMsg += fmt.Sprintf(" %s (body: '%s')", hintMsg, bs)
 				}
 			}
-			return "", fmt.Errorf("Downloading tags info: %s", errMsg)
+			return "", fmt.Errorf("downloading tags info: %s", errMsg)
 		}
 		for _, tag := range tagList {
 			if tag != nil && tag.Name != nil {
 				tags = append(tags, *tag.Name)
 			} else {
-				return "", fmt.Errorf("Name not found for downloaded tag: %v", tag)
+				return "", fmt.Errorf("name not found for downloaded tag: %v", tag)
 			}
 		}
 		if resp.NextPage == 0 {
@@ -269,7 +269,7 @@ func (d Sync) fetchTagSelection() (string, error) {
 
 	tag, err := ctlver.HighestConstrainedVersion(tags, *d.opts.TagSelection)
 	if err != nil {
-		return "", fmt.Errorf("Failed to find tag matching tagSelection %v : %s", d.opts.TagSelection.Semver, err)
+		return "", fmt.Errorf("failed to find tag matching tagSelection %v : %s", d.opts.TagSelection.Semver, err)
 	}
 	return tag, err
 }
@@ -283,12 +283,12 @@ func (d Sync) downloadRelease(authToken string) (ReleaseAPI, error) {
 	}
 	respBytes, err := d.downloadAPIResponse(url, authToken)
 	if err != nil {
-		return releaseAPI, fmt.Errorf("Downloading release details from %s : %s", url, err.Error())
+		return releaseAPI, fmt.Errorf("downloading release details from %s : %s", url, err.Error())
 	}
 
 	err = json.Unmarshal(respBytes, &releaseAPI)
 	if err != nil {
-		return releaseAPI, fmt.Errorf("Parsing response from: %s error: %s", url, err.Error())
+		return releaseAPI, fmt.Errorf("parsing response from: %s error: %s", url, err.Error())
 	}
 
 	return releaseAPI, nil
@@ -381,7 +381,7 @@ func (d Sync) checkFileSize(path string, expectedSize int64) error {
 		return err
 	}
 	if fi.Size() != expectedSize {
-		return fmt.Errorf("Expected file size to be %d, but was %d", expectedSize, fi.Size())
+		return fmt.Errorf("expected file size to be %d, but was %d", expectedSize, fi.Size())
 	}
 	return nil
 }
@@ -400,13 +400,13 @@ func (d Sync) checkFileChecksum(path string, expectedChecksum string) error {
 	hash := sha256.New()
 	_, err = io.Copy(hash, f)
 	if err != nil {
-		return fmt.Errorf("Calculating checksum: %s", err)
+		return fmt.Errorf("calculating checksum: %s", err)
 	}
 
 	actualChecksum := fmt.Sprintf("%x", hash.Sum(nil))
 
 	if actualChecksum != expectedChecksum {
-		return fmt.Errorf("Expected file checksum to be '%s', but was '%s'",
+		return fmt.Errorf("expected file checksum to be '%s', but was '%s'",
 			expectedChecksum, actualChecksum)
 	}
 	return nil
@@ -430,7 +430,7 @@ func (d Sync) authToken() (string, error) {
 			case ctlconf.SecretGithubAPIToken:
 				token = string(val)
 			default:
-				return "", fmt.Errorf("Unknown secret field '%s' in secret '%s'", name, secret.Metadata.Name)
+				return "", fmt.Errorf("unknown secret field '%s' in secret '%s'", name, secret.Metadata.Name)
 			}
 		}
 	}

--- a/pkg/vendir/fetch/helmchart/http_source.go
+++ b/pkg/vendir/fetch/helmchart/http_source.go
@@ -60,7 +60,7 @@ func (t *HTTPSource) init(helmHomeDir string) error {
 			return nil
 		}
 
-		return fmt.Errorf("Init helm: %s (stderr: %s)", err, stderrStr)
+		return fmt.Errorf("init helm: %s (stderr: %s)", err, stderrStr)
 	}
 
 	return nil
@@ -89,7 +89,7 @@ func (t *HTTPSource) fetch(helmHomeDir, chartsPath string) error {
 
 	if t.opts.Repository != nil {
 		if len(t.opts.Repository.URL) == 0 {
-			return fmt.Errorf("Expected non-empty repository URL")
+			return fmt.Errorf("expected non-empty repository URL")
 		}
 		repoURL = t.opts.Repository.URL
 	}
@@ -100,7 +100,7 @@ func (t *HTTPSource) fetch(helmHomeDir, chartsPath string) error {
 			repoAddArgs := []string{"repo", "add", "vendir-unused", repoURL}
 			repoAddArgs, err := t.addAuthArgs(repoAddArgs)
 			if err != nil {
-				return fmt.Errorf("Adding helm chart auth info: %s", err)
+				return fmt.Errorf("adding helm chart auth info: %s", err)
 			}
 
 			var stdoutBs, stderrBs bytes.Buffer
@@ -112,7 +112,7 @@ func (t *HTTPSource) fetch(helmHomeDir, chartsPath string) error {
 
 			err = cmd.Run()
 			if err != nil {
-				return fmt.Errorf("Add helm chart repository: %s (stderr: %s)", err, stderrBs.String())
+				return fmt.Errorf("add helm chart repository: %s (stderr: %s)", err, stderrBs.String())
 			}
 		}
 
@@ -122,7 +122,7 @@ func (t *HTTPSource) fetch(helmHomeDir, chartsPath string) error {
 
 		fetchArgs, err = t.addAuthArgs(fetchArgs)
 		if err != nil {
-			return fmt.Errorf("Adding helm chart auth info: %s", err)
+			return fmt.Errorf("adding helm chart auth info: %s", err)
 		}
 	}
 
@@ -135,7 +135,7 @@ func (t *HTTPSource) fetch(helmHomeDir, chartsPath string) error {
 
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("Fetching helm chart: %s (stderr: %s)", err, stderrBs.String())
+		return fmt.Errorf("fetching helm chart: %s (stderr: %s)", err, stderrBs.String())
 	}
 
 	return nil
@@ -157,7 +157,7 @@ func (t *HTTPSource) addAuthArgs(args []string) ([]string, error) {
 			case ctlconf.SecretK8sCorev1BasicAuthPasswordKey:
 				authArgs = append(authArgs, []string{"--password", string(val)}...)
 			default:
-				return nil, fmt.Errorf("Unknown secret field '%s' in secret '%s'", name, secret.Metadata.Name)
+				return nil, fmt.Errorf("unknown secret field '%s' in secret '%s'", name, secret.Metadata.Name)
 			}
 		}
 	}

--- a/pkg/vendir/fetch/helmchart/oci_source.go
+++ b/pkg/vendir/fetch/helmchart/oci_source.go
@@ -58,13 +58,13 @@ func NewOCISource(opts ctlconf.DirectoryContentsHelmChart,
 
 func (t *OCISource) Fetch(dstPath string, tempArea ctlfetch.TempArea) error {
 	if len(t.opts.Name) == 0 {
-		return fmt.Errorf("Expected non-empty name")
+		return fmt.Errorf("expected non-empty name")
 	}
 	if len(t.opts.Version) == 0 {
-		return fmt.Errorf("Expected non-empty version")
+		return fmt.Errorf("expected non-empty version")
 	}
 	if t.opts.Repository == nil || len(t.opts.Repository.URL) == 0 {
-		return fmt.Errorf("Expected non-empty repository URL")
+		return fmt.Errorf("expected non-empty repository URL")
 	}
 
 	helmHomeDir, err := tempArea.NewTempDir("helm-home")
@@ -97,7 +97,7 @@ func (t *OCISource) Fetch(dstPath string, tempArea ctlfetch.TempArea) error {
 func (t *OCISource) login(repo, helmHomeDir string) error {
 	authArgs, cmdStdin, err := t.addAuthArgs([]string{})
 	if err != nil {
-		return fmt.Errorf("Adding helm auth info: %s", err)
+		return fmt.Errorf("adding helm auth info: %s", err)
 	}
 
 	if len(authArgs) == 0 {
@@ -117,7 +117,7 @@ func (t *OCISource) login(repo, helmHomeDir string) error {
 
 	err = cmd.Run()
 	if err != nil {
-		return fmt.Errorf("Helm registry login: %s (stderr: %s)", err, stderrBs.String())
+		return fmt.Errorf("helm registry login: %s (stderr: %s)", err, stderrBs.String())
 	}
 
 	return nil
@@ -135,7 +135,7 @@ func (t *OCISource) pull(ref, helmHomeDir, dstPath string) error {
 
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("Helm chart pull: %s (stderr: %s)", err, stderrBs.String())
+		return fmt.Errorf("helm chart pull: %s (stderr: %s)", err, stderrBs.String())
 	}
 
 	return nil
@@ -158,7 +158,7 @@ func (t *OCISource) addAuthArgs(args []string) ([]string, io.Reader, error) {
 
 		if len(secrets) > 1 {
 			// If there are more than 1, then which one would we pick?
-			return nil, nil, fmt.Errorf("Expected 0 or 1 registry auth credential, but found %d", len(secrets))
+			return nil, nil, fmt.Errorf("expected 0 or 1 registry auth credential, but found %d", len(secrets))
 		}
 
 		for _, secret := range secrets {
@@ -173,7 +173,7 @@ func (t *OCISource) addAuthArgs(args []string) ([]string, io.Reader, error) {
 					authArgs = append(authArgs, []string{"--password-stdin"}...)
 					passwordStdin = strings.NewReader(string(val))
 				default:
-					return nil, nil, fmt.Errorf("Unknown secret field '%s' in secret '%s'", name, secret.Metadata.Name)
+					return nil, nil, fmt.Errorf("unknown secret field '%s' in secret '%s'", name, secret.Metadata.Name)
 				}
 			}
 		}

--- a/pkg/vendir/fetch/helmchart/sync.go
+++ b/pkg/vendir/fetch/helmchart/sync.go
@@ -50,7 +50,7 @@ func (t *Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDir
 	lockConf := ctlconf.LockDirectoryContentsHelmChart{}
 
 	if len(t.opts.Name) == 0 {
-		return lockConf, fmt.Errorf("Expected non-empty name")
+		return lockConf, fmt.Errorf("expected non-empty name")
 	}
 
 	chartsDir, err := tempArea.NewTempDir("helm-chart")
@@ -74,12 +74,12 @@ func (t *Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDir
 
 	chartPath, err := t.findChartDir(chartsDir)
 	if err != nil {
-		return lockConf, fmt.Errorf("Finding single helm chart: %s", err)
+		return lockConf, fmt.Errorf("finding single helm chart: %s", err)
 	}
 
 	meta, err := t.retrieveChartMeta(chartPath)
 	if err != nil {
-		return lockConf, fmt.Errorf("Retrieving helm chart metadata: %s", err)
+		return lockConf, fmt.Errorf("retrieving helm chart metadata: %s", err)
 	}
 
 	err = ctlfetch.MoveDir(chartPath, dstPath)
@@ -103,7 +103,7 @@ func (t *Sync) retrieveChartMeta(chartPath string) (chartMeta, error) {
 
 	bs, err := os.ReadFile(filepath.Join(chartPath, "Chart.yaml"))
 	if err != nil {
-		return meta, fmt.Errorf("Reading Chart.yaml: %s", err)
+		return meta, fmt.Errorf("reading Chart.yaml: %s", err)
 	}
 
 	err = yaml.Unmarshal(bs, &meta)
@@ -112,7 +112,7 @@ func (t *Sync) retrieveChartMeta(chartPath string) (chartMeta, error) {
 	}
 
 	if len(meta.Version) == 0 {
-		return meta, fmt.Errorf("Expected non-empty chart version")
+		return meta, fmt.Errorf("expected non-empty chart version")
 	}
 
 	return meta, nil
@@ -132,7 +132,7 @@ func (t *Sync) findChartDir(chartsPath string) (string, error) {
 	}
 
 	if len(dirNames) != 1 {
-		return "", fmt.Errorf("Expected single directory in charts directory, but was: %s", dirNames)
+		return "", fmt.Errorf("expected single directory in charts directory, but was: %s", dirNames)
 	}
 	return filepath.Join(chartsPath, dirNames[0]), nil
 }

--- a/pkg/vendir/fetch/hg/hg.go
+++ b/pkg/vendir/fetch/hg/hg.go
@@ -115,7 +115,7 @@ func (t *Hg) Close() {
 
 func (t *Hg) setup(tempArea ctlfetch.TempArea) error {
 	if len(t.opts.URL) == 0 {
-		return fmt.Errorf("Expected non-empty URL")
+		return fmt.Errorf("expected non-empty URL")
 	}
 
 	cacheID := t.opts.URL
@@ -144,11 +144,11 @@ func (t *Hg) setup(tempArea ctlfetch.TempArea) error {
 
 	if authOpts.Username != nil && authOpts.Password != nil {
 		if !strings.HasPrefix(hgURL, "https://") {
-			return fmt.Errorf("Username/password authentication is only supported for https remotes")
+			return fmt.Errorf("username/password authentication is only supported for https remotes")
 		}
 		hgCredsURL, err := url.Parse(hgURL)
 		if err != nil {
-			return fmt.Errorf("Parsing hg remote url: %s", err)
+			return fmt.Errorf("parsing hg remote url: %s", err)
 		}
 
 		hgRc = fmt.Sprintf(`%s
@@ -168,7 +168,7 @@ hgauth.password = %s
 
 			err = os.WriteFile(path, []byte(*authOpts.PrivateKey), 0600)
 			if err != nil {
-				return fmt.Errorf("Writing private key: %s", err)
+				return fmt.Errorf("writing private key: %s", err)
 			}
 
 			sshCmd = append(sshCmd, "-i", path, "-o", "IdentitiesOnly=yes")
@@ -179,7 +179,7 @@ hgauth.password = %s
 
 			err = os.WriteFile(path, []byte(*authOpts.KnownHosts), 0600)
 			if err != nil {
-				return fmt.Errorf("Writing known hosts: %s", err)
+				return fmt.Errorf("writing known hosts: %s", err)
 			}
 
 			sshCmd = append(sshCmd, "-o", "StrictHostKeyChecking=yes", "-o", "UserKnownHostsFile="+path)
@@ -194,7 +194,7 @@ hgauth.password = %s
 		hgRcPath := filepath.Join(authDir, "hgrc")
 		err = os.WriteFile(hgRcPath, []byte(hgRc), 0600)
 		if err != nil {
-			return fmt.Errorf("Writing %s: %s", hgRcPath, err)
+			return fmt.Errorf("writing %s: %s", hgRcPath, err)
 		}
 		t.env = append(t.env, "HGRCPATH="+hgRcPath)
 	}
@@ -217,7 +217,7 @@ func (t *Hg) initClone(dstPath string) error {
 	repoHgRc := fmt.Sprintf("[paths]\ndefault = %s\n", hgURL)
 
 	if err := os.WriteFile(repoHgRcPath, []byte(repoHgRc), 0600); err != nil {
-		return fmt.Errorf("Writing %s: %s", repoHgRcPath, err)
+		return fmt.Errorf("writing %s: %s", repoHgRcPath, err)
 	}
 
 	return nil
@@ -236,7 +236,7 @@ func (t *Hg) run(args []string, dstPath string) (string, string, error) {
 
 	err := cmd.Run()
 	if err != nil {
-		return "", "", fmt.Errorf("Hg %s: %s (stderr: %s)", args, err, stderrBs.String())
+		return "", "", fmt.Errorf("hg %s: %s (stderr: %s)", args, err, stderrBs.String())
 	}
 
 	return stdoutBs.String(), stderrBs.String(), nil
@@ -277,7 +277,7 @@ func (t *Hg) getAuthOpts() (hgAuthOpts, error) {
 				password := string(val)
 				opts.Password = &password
 			default:
-				return opts, fmt.Errorf("Unknown secret field '%s' in secret '%s'", name, t.opts.SecretRef.Name)
+				return opts, fmt.Errorf("unknown secret field '%s' in secret '%s'", name, t.opts.SecretRef.Name)
 			}
 		}
 	}

--- a/pkg/vendir/fetch/hg/sync.go
+++ b/pkg/vendir/fetch/hg/sync.go
@@ -48,38 +48,38 @@ func (d Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDire
 
 	hg, err := NewHg(d.opts, d.log, d.refFetcher, tempArea)
 	if err != nil {
-		return hgLockConf, fmt.Errorf("Setting up hg: %w", err)
+		return hgLockConf, fmt.Errorf("setting up hg: %w", err)
 	}
 	defer hg.Close()
 
 	if cachePath, ok := d.cache.Has("hg", hg.getCacheID()); ok {
 		// fetch from cachedDir
 		if err := d.cache.CopyFrom("hg", hg.getCacheID(), incomingTmpPath); err != nil {
-			return hgLockConf, fmt.Errorf("Extracting cached hg clone: %w", err)
+			return hgLockConf, fmt.Errorf("extracting cached hg clone: %w", err)
 		}
 		// Sync if needed
 		if !hg.cloneHasTargetRef(cachePath) {
 			if err := hg.syncClone(incomingTmpPath); err != nil {
-				return hgLockConf, fmt.Errorf("Syncing hg repository: %w", err)
+				return hgLockConf, fmt.Errorf("syncing hg repository: %w", err)
 			}
 			if err := d.cache.Save("hg", hg.getCacheID(), incomingTmpPath); err != nil {
-				return hgLockConf, fmt.Errorf("Saving hg repository to cache: %w", err)
+				return hgLockConf, fmt.Errorf("saving hg repository to cache: %w", err)
 			}
 		}
 	} else {
 		// fetch in the target directory
 		if err := hg.clone(incomingTmpPath); err != nil {
-			return hgLockConf, fmt.Errorf("Cloning hg repository: %w", err)
+			return hgLockConf, fmt.Errorf("cloning hg repository: %w", err)
 		}
 		if err := d.cache.Save("hg", hg.getCacheID(), incomingTmpPath); err != nil {
-			return hgLockConf, fmt.Errorf("Saving hg repository to cache: %w", err)
+			return hgLockConf, fmt.Errorf("saving hg repository to cache: %w", err)
 		}
 	}
 
 	// now checkout the wanted revision
 	info, err := hg.checkout(incomingTmpPath)
 	if err != nil {
-		return hgLockConf, fmt.Errorf("Checking out hg repository: %s", err)
+		return hgLockConf, fmt.Errorf("checking out hg repository: %s", err)
 	}
 
 	hgLockConf.SHA = info.SHA
@@ -87,12 +87,12 @@ func (d Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDire
 
 	err = os.RemoveAll(dstPath)
 	if err != nil {
-		return hgLockConf, fmt.Errorf("Deleting dir %s: %s", dstPath, err)
+		return hgLockConf, fmt.Errorf("deleting dir %s: %s", dstPath, err)
 	}
 
 	err = os.Rename(incomingTmpPath, dstPath)
 	if err != nil {
-		return hgLockConf, fmt.Errorf("Moving directory '%s' to staging dir: %s", incomingTmpPath, err)
+		return hgLockConf, fmt.Errorf("moving directory '%s' to staging dir: %s", incomingTmpPath, err)
 	}
 
 	return hgLockConf, nil

--- a/pkg/vendir/fetch/http/sync.go
+++ b/pkg/vendir/fetch/http/sync.go
@@ -30,7 +30,7 @@ func (t *Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDir
 	lockConf := ctlconf.LockDirectoryContentsHTTP{}
 
 	if len(t.opts.URL) == 0 {
-		return lockConf, fmt.Errorf("Expected non-empty URL")
+		return lockConf, fmt.Errorf("expected non-empty URL")
 	}
 
 	tmpFile, err := tempArea.NewTempFile("vendir-http")
@@ -43,7 +43,7 @@ func (t *Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDir
 	err = t.downloadFileAndChecksum(tmpFile)
 	if err != nil {
 		tmpFile.Close()
-		return lockConf, fmt.Errorf("Downloading URL: %s", err)
+		return lockConf, fmt.Errorf("downloading URL: %s", err)
 	}
 
 	incomingTmpPath := filepath.Dir(tmpFile.Name())
@@ -64,7 +64,7 @@ func (t *Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDir
 
 		_, err = ctlfetch.NewArchive(archivePath, true, t.opts.URL).Unpack(incomingTmpPath)
 		if err != nil {
-			return lockConf, fmt.Errorf("Unpacking archive: %s", err)
+			return lockConf, fmt.Errorf("unpacking archive: %s", err)
 		}
 
 		err = ctlfetch.MoveDir(incomingTmpPath, dstPath)
@@ -78,28 +78,28 @@ func (t *Sync) Sync(dstPath string, tempArea ctlfetch.TempArea) (ctlconf.LockDir
 func (t *Sync) downloadFile(dst io.Writer) error {
 	req, err := http.NewRequest("GET", t.opts.URL, nil)
 	if err != nil {
-		return fmt.Errorf("Building request: %s", err)
+		return fmt.Errorf("building request: %s", err)
 	}
 
 	err = t.addAuth(req)
 	if err != nil {
-		return fmt.Errorf("Adding auth to request: %s", err)
+		return fmt.Errorf("adding auth to request: %s", err)
 	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("Initiating URL download: %s", err)
+		return fmt.Errorf("initiating URL download: %s", err)
 	}
 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Expected 200 OK, but was '%s'", resp.Status)
+		return fmt.Errorf("expected 200 OK, but was '%s'", resp.Status)
 	}
 
 	_, err = io.Copy(dst, resp.Body)
 	if err != nil {
-		return fmt.Errorf("Writing downloaded content: %s", err)
+		return fmt.Errorf("writing downloaded content: %s", err)
 	}
 
 	return nil
@@ -149,7 +149,7 @@ func (t *Sync) addAuth(req *http.Request) error {
 		case ctlconf.SecretK8sCorev1BasicAuthUsernameKey:
 		case ctlconf.SecretK8sCorev1BasicAuthPasswordKey:
 		default:
-			return fmt.Errorf("Unknown secret field '%s' in secret '%s'", name, secret.Metadata.Name)
+			return fmt.Errorf("unknown secret field '%s' in secret '%s'", name, secret.Metadata.Name)
 		}
 	}
 

--- a/pkg/vendir/fetch/image/imgpkg.go
+++ b/pkg/vendir/fetch/image/imgpkg.go
@@ -171,7 +171,7 @@ func (t *Imgpkg) RegistryOpts() (registry.Opts, error) {
 	for _, envVar := range append(envVariables, t.opts.EnvironFunc()...) {
 		envVarSplit := strings.SplitN(envVar, "=", 2)
 		if len(envVarSplit) != 2 {
-			return registry.Opts{}, fmt.Errorf("Value '%s' does not look like an environment variable", envVar)
+			return registry.Opts{}, fmt.Errorf("value '%s' does not look like an environment variable", envVar)
 		}
 		envVars[envVarSplit[0]] = envVarSplit[1]
 	}
@@ -213,7 +213,7 @@ func (t *Imgpkg) authEnv() ([]string, error) {
 					case ctlconf.SecretRegistryBearerToken:
 						authEnv = append(authEnv, fmt.Sprintf("IMGPKG_REGISTRY_REGISTRY_TOKEN_%d=%s", i, val))
 					default:
-						return nil, fmt.Errorf("Unknown secret field '%s' in secret '%s'", name, secret.Metadata.Name)
+						return nil, fmt.Errorf("unknown secret field '%s' in secret '%s'", name, secret.Metadata.Name)
 					}
 				}
 			} else {
@@ -226,7 +226,7 @@ func (t *Imgpkg) authEnv() ([]string, error) {
 					case ctlconf.SecretRegistryBearerToken:
 						authEnv = append(authEnv, fmt.Sprintf("IMGPKG_TOKEN=%s", val))
 					default:
-						return nil, fmt.Errorf("Unknown secret field '%s' in secret '%s'", name, secret.Metadata.Name)
+						return nil, fmt.Errorf("unknown secret field '%s' in secret '%s'", name, secret.Metadata.Name)
 					}
 				}
 			}

--- a/pkg/vendir/fetch/image/sync.go
+++ b/pkg/vendir/fetch/image/sync.go
@@ -62,7 +62,7 @@ func (t *Sync) Sync(dstPath string) (ctlconf.LockDirectoryContentsImage, error) 
 
 func (t *Sync) resolveURL() (string, error) {
 	if len(t.opts.URL) == 0 {
-		return "", fmt.Errorf("Expected non-empty URL")
+		return "", fmt.Errorf("expected non-empty URL")
 	}
 
 	if t.opts.TagSelection != nil {
@@ -73,7 +73,7 @@ func (t *Sync) resolveURL() (string, error) {
 
 		selectedTag, err := ctlver.HighestConstrainedVersion(tags, *t.opts.TagSelection)
 		if err != nil {
-			return "", fmt.Errorf("Determining tag selection: %s", err)
+			return "", fmt.Errorf("determining tag selection: %s", err)
 		}
 
 		// In case URL erroneously contains tag or digest,

--- a/pkg/vendir/fetch/imgpkgbundle/sync.go
+++ b/pkg/vendir/fetch/imgpkgbundle/sync.go
@@ -71,7 +71,7 @@ func (t *Sync) Sync(dstPath string) (ctlconf.LockDirectoryContentsImgpkgBundle, 
 
 func (t *Sync) resolveImage() (string, error) {
 	if len(t.opts.Image) == 0 {
-		return "", fmt.Errorf("Expected non-empty image")
+		return "", fmt.Errorf("expected non-empty image")
 	}
 
 	if t.opts.TagSelection != nil {
@@ -82,7 +82,7 @@ func (t *Sync) resolveImage() (string, error) {
 
 		selectedTag, err := ctlver.HighestConstrainedVersion(tags, *t.opts.TagSelection)
 		if err != nil {
-			return "", fmt.Errorf("Determining tag selection: %s", err)
+			return "", fmt.Errorf("determining tag selection: %s", err)
 		}
 
 		// In case image erroneously contains tag or digest,

--- a/pkg/vendir/fetch/inline/sync.go
+++ b/pkg/vendir/fetch/inline/sync.go
@@ -46,7 +46,7 @@ func (t *Sync) Sync(dstPath string) (ctlconf.LockDirectoryContentsInline, error)
 			}
 
 		default:
-			return lockConf, fmt.Errorf("Expected either secretRef or configMapRef as a source")
+			return lockConf, fmt.Errorf("expected either secretRef or configMapRef as a source")
 		}
 	}
 
@@ -95,12 +95,12 @@ func (t *Sync) writeFile(dstPath, subPath string, content string) error {
 
 	err = os.MkdirAll(parentDir, 0700)
 	if err != nil {
-		return fmt.Errorf("Making parent directory '%s': %s", parentDir, err)
+		return fmt.Errorf("making parent directory '%s': %s", parentDir, err)
 	}
 
 	err = os.WriteFile(newPath, []byte(content), 0600)
 	if err != nil {
-		return fmt.Errorf("Writing file '%s': %s", newPath, err)
+		return fmt.Errorf("writing file '%s': %s", newPath, err)
 	}
 
 	return nil

--- a/pkg/vendir/fetch/move.go
+++ b/pkg/vendir/fetch/move.go
@@ -14,12 +14,12 @@ import (
 func MoveDir(path, dstPath string) error {
 	err := os.RemoveAll(dstPath)
 	if err != nil {
-		return fmt.Errorf("Deleting dir %s: %s", dstPath, err)
+		return fmt.Errorf("deleting dir %s: %s", dstPath, err)
 	}
 
 	err = os.Rename(path, dstPath)
 	if err != nil {
-		return fmt.Errorf("Moving directory '%s' to staging dir: %s", path, err)
+		return fmt.Errorf("moving directory '%s' to staging dir: %s", path, err)
 	}
 
 	return nil
@@ -33,18 +33,18 @@ func MoveFile(path, dstPath string) error {
 	if !errors.Is(err, &os.PathError{}) {
 		err := os.RemoveAll(dstPath)
 		if err != nil {
-			return fmt.Errorf("Deleting dir %s: %s", dstPath, err)
+			return fmt.Errorf("deleting dir %s: %s", dstPath, err)
 		}
 	}
 
 	err = os.Mkdir(dstPath, folderPermission)
 	if err != nil {
-		return fmt.Errorf("Creating dir %s: %s", dstPath, err)
+		return fmt.Errorf("creating dir %s: %s", dstPath, err)
 	}
 
 	err = os.Rename(path, filepath.Join(dstPath, filepath.Base(path)))
 	if err != nil {
-		return fmt.Errorf("Moving file '%s' to staging dir: %s", path, err)
+		return fmt.Errorf("moving file '%s' to staging dir: %s", path, err)
 	}
 
 	return nil
@@ -53,19 +53,19 @@ func MoveFile(path, dstPath string) error {
 func ScopedPath(path, subPath string) (string, error) {
 	path, err := filepath.Abs(path)
 	if err != nil {
-		return "", fmt.Errorf("Abs path: %s", err)
+		return "", fmt.Errorf("abs path: %s", err)
 	}
 
 	newPath, err := filepath.Abs(filepath.Join(path, subPath))
 	if err != nil {
-		return "", fmt.Errorf("Abs path: %s", err)
+		return "", fmt.Errorf("abs path: %s", err)
 	}
 
 	// Check that subPath is contained within path (disallow this scenario):
 	//   ScopedPath("/root", "../root-trick/file1")
 	//   "/root-trick/file1" == "/root" + "../root-trick/file1"
 	if newPath != path && !strings.HasPrefix(newPath, path+string(filepath.Separator)) {
-		return "", fmt.Errorf("Invalid path: %s", subPath)
+		return "", fmt.Errorf("invalid path: %s", subPath)
 	}
 
 	return newPath, nil

--- a/pkg/vendir/fetch/ref_fetcher.go
+++ b/pkg/vendir/fetch/ref_fetcher.go
@@ -24,9 +24,9 @@ func (f SingleSecretRefFetcher) GetSecret(name string) (ctlconf.Secret, error) {
 	if f.Secret != nil && f.Secret.Metadata.Name == name {
 		return *f.Secret, nil
 	}
-	return ctlconf.Secret{}, fmt.Errorf("Not found")
+	return ctlconf.Secret{}, fmt.Errorf("not found")
 }
 
 func (f SingleSecretRefFetcher) GetConfigMap(_ string) (ctlconf.ConfigMap, error) {
-	return ctlconf.ConfigMap{}, fmt.Errorf("Not found")
+	return ctlconf.ConfigMap{}, fmt.Errorf("not found")
 }

--- a/pkg/vendir/openpgparmor/armor.go
+++ b/pkg/vendir/openpgparmor/armor.go
@@ -15,7 +15,7 @@ func ReadArmoredKeys(keys string) (openpgp.EntityList, error) {
 
 	parts := strings.Split(keys, startMarker)
 	if len(parts) == 1 {
-		return nil, fmt.Errorf("Expected to find armored block, but did not")
+		return nil, fmt.Errorf("expected to find armored block, but did not")
 	}
 
 	var result openpgp.EntityList
@@ -27,7 +27,7 @@ func ReadArmoredKeys(keys string) (openpgp.EntityList, error) {
 
 		el, err := openpgp.ReadArmoredKeyRing(strings.NewReader(startMarker + part))
 		if err != nil {
-			return nil, fmt.Errorf("Reading armored key [idx=%d]: %s", i, err)
+			return nil, fmt.Errorf("reading armored key [idx=%d]: %s", i, err)
 		}
 
 		result = append(result, el...)

--- a/pkg/vendir/versions/selector.go
+++ b/pkg/vendir/versions/selector.go
@@ -39,7 +39,7 @@ func HighestConstrainedVersionWithAdditionalConstraints(versions []string, confi
 			var err error
 			matchedVers, err = matchedVers.FilterConstraints(config.Semver.Constraints)
 			if err != nil {
-				return "", fmt.Errorf("Selecting versions: %s", err)
+				return "", fmt.Errorf("selecting versions: %s", err)
 			}
 			details = append(details, fmt.Sprintf("after-constraints-filter=%d", matchedVers.Len()))
 		}
@@ -52,6 +52,6 @@ func HighestConstrainedVersionWithAdditionalConstraints(versions []string, confi
 		return highestVersion, nil
 
 	default:
-		return "", fmt.Errorf("Unsupported version selection type (currently supported: semver)")
+		return "", fmt.Errorf("unsupported version selection type (currently supported: semver)")
 	}
 }

--- a/pkg/vendir/versions/semvers.go
+++ b/pkg/vendir/versions/semvers.go
@@ -75,7 +75,7 @@ func (v Semvers) Sorted() Semvers {
 func (v Semvers) FilterConstraints(constraintList string) (Semvers, error) {
 	constraints, err := semver.ParseRange(constraintList)
 	if err != nil {
-		return Semvers{}, fmt.Errorf("Parsing version constraint '%s': %s", constraintList, err)
+		return Semvers{}, fmt.Errorf("parsing version constraint '%s': %s", constraintList, err)
 	}
 
 	var matchingVersions []SemverWrap

--- a/test/e2e/example.go
+++ b/test/e2e/example.go
@@ -80,17 +80,17 @@ func (et example) check(t *testing.T, vendir Vendir) error {
 
 	vendorDir, err := os.Stat(vendorPath)
 	if err != nil {
-		return fmt.Errorf("Expected no err for stat: %v", err)
+		return fmt.Errorf("expected no err for stat: %v", err)
 	}
 	if !vendorDir.IsDir() {
-		return fmt.Errorf("Expected to be dir")
+		return fmt.Errorf("expected to be dir")
 	}
 
 	// remove all vendored bits
 	if !et.SkipRemove {
 		err = os.RemoveAll(vendorPath)
 		if err != nil {
-			return fmt.Errorf("Expected no err for remove all")
+			return fmt.Errorf("expected no err for remove all")
 		}
 	}
 
@@ -103,13 +103,13 @@ func (et example) check(t *testing.T, vendir Vendir) error {
 	if !et.OnlyLocked {
 		_, err = vendir.RunWithOpts([]string{"sync"}, RunOpts{Dir: path, Env: et.Env})
 		if err != nil {
-			return fmt.Errorf("Expected no err for sync")
+			return fmt.Errorf("expected no err for sync")
 		}
 
 		// This assumes that example's vendor directory is committed to git
 		gitOut := gitDiffExamplesDir(t, dir, "../../")
 		if gitOut != "" {
-			return fmt.Errorf("Expected no diff, but was: >>>%s<<<", gitOut)
+			return fmt.Errorf("expected no diff, but was: >>>%s<<<", gitOut)
 		}
 	}
 
@@ -118,7 +118,7 @@ func (et example) check(t *testing.T, vendir Vendir) error {
 
 	_, err = vendir.RunWithOpts([]string{"sync", "--locked"}, RunOpts{Dir: path, Env: et.Env})
 	if err != nil {
-		return fmt.Errorf("Expected no err for sync locked")
+		return fmt.Errorf("expected no err for sync locked")
 	}
 
 	newLockFileStat, err := os.Stat(filepath.Join(path, "vendir.lock.yml"))
@@ -127,7 +127,7 @@ func (et example) check(t *testing.T, vendir Vendir) error {
 
 	gitOut := gitDiffExamplesDir(t, path, tmpDir)
 	if gitOut != "" {
-		return fmt.Errorf("Expected no diff, but was: >>>%s<<<", gitOut)
+		return fmt.Errorf("expected no diff, but was: >>>%s<<<", gitOut)
 	}
 
 	return nil

--- a/test/e2e/git_util.go
+++ b/test/e2e/git_util.go
@@ -34,7 +34,7 @@ func execGit(args []string, dir string) (string, string, error) {
 
 	err := cmd.Run()
 	if err != nil {
-		return "", "", fmt.Errorf("Git %s: %s (stderr: %s)", args, err, stderrBs.String())
+		return "", "", fmt.Errorf("git %s: %s (stderr: %s)", args, err, stderrBs.String())
 	}
 
 	return stdoutBs.String(), stderrBs.String(), nil

--- a/test/e2e/vendir.go
+++ b/test/e2e/vendir.go
@@ -80,7 +80,7 @@ func (k Vendir) RunWithOpts(args []string, opts RunOpts) (string, error) {
 	stdoutStr := stdout.String()
 
 	if err != nil {
-		err = fmt.Errorf("Execution error: stdout: '%s' stderr: '%s' error: '%s'", stdoutStr, stderr.String(), err)
+		err = fmt.Errorf("execution error: stdout: '%s' stderr: '%s' error: '%s'", stdoutStr, stderr.String(), err)
 
 		if !opts.AllowError {
 			k.t.Fatalf("Failed to successfully execute '%s': %v", k.cmdDesc(args, opts), err)


### PR DESCRIPTION
This fixes the staticcheck error ST1005, which states that error strings should not be capitalized.
Ref: https://staticcheck.dev/docs/checks#ST1005
