### PR TITLE
Fix #423

### DIFF
--- a/pkg/vendir/fetch/helmchart/sync.go
+++ b/pkg/vendir/fetch/helmchart/sync.go
@@ -126,7 +126,6 @@ func (t *Sync) findChartDir(chartsPath string) (string, error) {
 
 	var dirNames []string
 	for _, file := range files {
-		// #423 - instead of relying on a naming convention, collect paths that contain a Chart.yaml
 		if _, ignored := os.Stat(filepath.Join(chartsPath, file.Name(), "Chart.yaml")); ignored == nil {
 			dirNames = append(dirNames, file.Name())
 		}

--- a/pkg/vendir/fetch/helmchart/sync.go
+++ b/pkg/vendir/fetch/helmchart/sync.go
@@ -126,7 +126,9 @@ func (t *Sync) findChartDir(chartsPath string) (string, error) {
 
 	var dirNames []string
 	for _, file := range files {
-		if _, ignored := os.Stat(filepath.Join(chartsPath, file.Name(), "Chart.yaml")); ignored == nil {
+		if _, ignored := os.Stat(filepath.Join(chartsPath,
+			file.Name(),
+			"Chart.yaml")); ignored == nil {
 			dirNames = append(dirNames, file.Name())
 		}
 	}

--- a/pkg/vendir/fetch/helmchart/sync.go
+++ b/pkg/vendir/fetch/helmchart/sync.go
@@ -126,7 +126,8 @@ func (t *Sync) findChartDir(chartsPath string) (string, error) {
 
 	var dirNames []string
 	for _, file := range files {
-		if file.IsDir() && !strings.HasSuffix(file.Name(), ".tgz") {
+		// #423 - instead of relying on a naming convention, collect paths that contain a Chart.yaml
+		if _, ignored := os.Stat(filepath.Join(chartsPath, file.Name(), "Chart.yaml")); ignored == nil {
 			dirNames = append(dirNames, file.Name())
 		}
 	}


### PR DESCRIPTION
== DETAILS

My proposed solution for this bug is, instead of relying on naming convention, we instead collect a list of subdirectories that contain `Chart.yaml`.

Credit to https://stackoverflow.com/a/12518877 for the idiomatic "check if file exists" example.