### PR TITLE
fix(git): optimize fetch to selectively include tags and checkout exct

### DIFF
--- a/pkg/vendir/fetch/git/git.go
+++ b/pkg/vendir/fetch/git/git.go
@@ -179,7 +179,10 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 			exactRef = true
 		} else {
 			// Only fetch tags if not fetching exact ref
-			argss = append(argss, []string{"config", "remote.origin.tagOpt", "--tags"})
+			argss = append(
+				argss,
+				[]string{"config", "remote.origin.tagOpt", "--tags"},
+			)
 		}
 		if t.opts.Depth > 0 {
 			fetchArgs = append(fetchArgs, "--depth", strconv.Itoa(t.opts.Depth))
@@ -209,7 +212,11 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 		checkoutRef = "FETCH_HEAD"
 	}
 
-	_, _, err = t.cmdRunner.Run([]string{"-c", "advice.detachedHead=false", "checkout", checkoutRef}, env, dstPath)
+	_, _, err = t.cmdRunner.Run(
+		[]string{"-c", "advice.detachedHead=false", "checkout", checkoutRef},
+		env,
+		dstPath,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/vendir/fetch/git/git.go
+++ b/pkg/vendir/fetch/git/git.go
@@ -166,17 +166,20 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 		}
 	}
 
-	argss = append(argss, []string{"config", "remote.origin.tagOpt", "--tags"})
-
 	if bundle != "" {
 		argss = append(argss, []string{"bundle", "unbundle", bundle})
 	}
 
+	exactRef := false
 	{
 		fetchArgs := []string{"fetch", "origin"}
 		if strings.HasPrefix(t.opts.Ref, "origin/") {
 			// only fetch the exact ref we're seeking
 			fetchArgs = append(fetchArgs, t.opts.Ref[7:])
+			exactRef = true
+		} else {
+			// Only fetch tags if not fetching exact ref
+			argss = append(argss, []string{"config", "remote.origin.tagOpt", "--tags"})
 		}
 		if t.opts.Depth > 0 {
 			fetchArgs = append(fetchArgs, "--depth", strconv.Itoa(t.opts.Depth))
@@ -201,7 +204,12 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 		}
 	}
 
-	_, _, err = t.cmdRunner.Run([]string{"-c", "advice.detachedHead=false", "checkout", ref}, env, dstPath)
+	checkoutRef := ref
+	if exactRef {
+		checkoutRef = "FETCH_HEAD"
+	}
+
+	_, _, err = t.cmdRunner.Run([]string{"-c", "advice.detachedHead=false", "checkout", checkoutRef}, env, dstPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is a continuation of https://github.com/carvel-dev/vendir/pull/427 simply with an additional stacked diff to address lint failures.

Hello,

I've enjoyed using this tool and would benefit from @fpytloun's tag fetching changes. I've made a quick change to hopefully fix the lint errors, and it seems to pass all tests locally. 

I don't seem to be able to more easily stack these changes with a PR on top of @fpytloun's work, so this is a new PR.


Thank you,
Cory