### PR TITLE
fix: support tar and tgz archives containing symbolic links

### DIFF
--- a/pkg/vendir/fetch/archive.go
+++ b/pkg/vendir/fetch/archive.go
@@ -158,12 +158,34 @@ func (t Archive) tryTarWithGzip(path, dstPath string, gzipped bool) (bool, error
 		case tar.TypeXGlobalHeader:
 			continue
 
+		case tar.TypeSymlink:
+			err = t.createSymlink(dstPath, header.Name, header.Linkname)
+			if err != nil {
+				return true, err
+			}
+
 		default:
-			return false, fmt.Errorf("Unknown file '%s' (%d)", header.Name, header.Typeflag)
+			return true, fmt.Errorf("Unsupported file type '%s' (%d)", header.Name, header.Typeflag)
 		}
 	}
 
 	return true, nil
+}
+
+func (t Archive) createSymlink(dstPath, symlinkPath, targetPath string) error {
+	fullSymlinkPath := filepath.Join(dstPath, symlinkPath)
+
+	err := os.MkdirAll(filepath.Dir(fullSymlinkPath), 0700)
+	if err != nil {
+		return fmt.Errorf("Making intermediate dir for symlink: %s", err)
+	}
+
+	err = os.Symlink(targetPath, fullSymlinkPath)
+	if err != nil {
+		return fmt.Errorf("Creating symlink: %s", err)
+	}
+
+	return nil
 }
 
 func (t Archive) tryPlain(path, dstPath string) error {

--- a/pkg/vendir/fetch/archive.go
+++ b/pkg/vendir/fetch/archive.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 )
 
+const defaultDirPermissions = 0700
+
 type Archive struct {
 	path               string
 	fallbackOnPlain    bool
@@ -49,7 +51,7 @@ func (t Archive) Unpack(dstPath string) (bool, error) {
 func (t Archive) writeIntoFile(srcFile io.Reader, dstPath, additionalPath string) error {
 	dstFilePath := filepath.Join(dstPath, additionalPath)
 
-	err := os.MkdirAll(filepath.Dir(dstFilePath), 0700)
+	err := os.MkdirAll(filepath.Dir(dstFilePath), defaultDirPermissions)
 	if err != nil {
 		return fmt.Errorf("Making intermediate dir: %s", err)
 	}
@@ -159,30 +161,34 @@ func (t Archive) tryTarWithGzip(path, dstPath string, gzipped bool) (bool, error
 			continue
 
 		case tar.TypeSymlink:
-			err = t.createSymlink(dstPath, header.Name, header.Linkname)
+			err = createSymlink(dstPath, header.Name, header.Linkname)
 			if err != nil {
 				return true, err
 			}
 
 		default:
-			return true, fmt.Errorf("Unsupported file type '%s' (%d)", header.Name, header.Typeflag)
+			return true, fmt.Errorf(
+				"unsupported file type '%s' (%d)",
+				header.Name,
+				header.Typeflag,
+			)
 		}
 	}
 
 	return true, nil
 }
 
-func (t Archive) createSymlink(dstPath, symlinkPath, targetPath string) error {
+func createSymlink(dstPath, symlinkPath, targetPath string) error {
 	fullSymlinkPath := filepath.Join(dstPath, symlinkPath)
 
-	err := os.MkdirAll(filepath.Dir(fullSymlinkPath), 0700)
+	err := os.MkdirAll(filepath.Dir(fullSymlinkPath), defaultDirPermissions)
 	if err != nil {
-		return fmt.Errorf("Making intermediate dir for symlink: %s", err)
+		return fmt.Errorf("making intermediate dir for symlink: %s", err)
 	}
 
 	err = os.Symlink(targetPath, fullSymlinkPath)
 	if err != nil {
-		return fmt.Errorf("Creating symlink: %s", err)
+		return fmt.Errorf("creating symlink: %s", err)
 	}
 
 	return nil

--- a/pkg/vendir/fetch/archive_test.go
+++ b/pkg/vendir/fetch/archive_test.go
@@ -15,10 +15,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	defaultDirMode     = 0755
+	defaultSymlinkMode = 0777
+	defaultFileMode    = 0644
+	noMode             = 0
+	lastCharIndex      = 1
+)
+
 // ArchiveEntry represents a simplified entry for creating archives in tests
 type ArchiveEntry struct {
 	Name     string // Path/name of the entry in the archive
-	Type     byte   // Type of entry: tar.TypeReg, tar.TypeDir, or tar.TypeSymlink
+	Type     byte   // Type: tar.TypeReg, tar.TypeDir, tar.TypeSymlink
 	Content  string // Content for regular files (ignored for dirs/symlinks)
 	Linkname string // Target for symlinks (ignored for files/dirs)
 	Mode     int64  // File mode (optional, defaults will be applied)
@@ -30,9 +38,14 @@ type TarOptions struct {
 }
 
 // createTar creates a tar file from a list of ArchiveEntry structs.
-// This is a reusable helper for creating test archives with various contents.
+// This is a reusable helper for creating test archives.
 // Use opts.Gzip to create a gzip-compressed tar.gz file.
-func createTar(t *testing.T, tarPath string, entries []ArchiveEntry, opts TarOptions) {
+func createTar(
+	t *testing.T,
+	tarPath string,
+	entries []ArchiveEntry,
+	opts TarOptions,
+) {
 	t.Helper()
 
 	file, err := os.Create(tarPath)
@@ -52,54 +65,90 @@ func createTar(t *testing.T, tarPath string, entries []ArchiveEntry, opts TarOpt
 	defer tarWriter.Close()
 
 	for _, entry := range entries {
-		mode := entry.Mode
-		if mode == 0 {
-			// Apply default modes based on type
-			switch entry.Type {
-			case tar.TypeDir:
-				mode = 0755
-			case tar.TypeSymlink:
-				mode = 0777
-			default:
-				mode = 0644
-			}
-		}
-
-		switch entry.Type {
-		case tar.TypeDir:
-			err = tarWriter.WriteHeader(&tar.Header{
-				Name:     entry.Name,
-				Mode:     mode,
-				Typeflag: tar.TypeDir,
-			})
-			require.NoError(t, err)
-
-		case tar.TypeReg:
-			content := []byte(entry.Content)
-			err = tarWriter.WriteHeader(&tar.Header{
-				Name:     entry.Name,
-				Mode:     mode,
-				Size:     int64(len(content)),
-				Typeflag: tar.TypeReg,
-			})
-			require.NoError(t, err)
-			_, err = tarWriter.Write(content)
-			require.NoError(t, err)
-
-		case tar.TypeSymlink:
-			err = tarWriter.WriteHeader(&tar.Header{
-				Name:     entry.Name,
-				Mode:     mode,
-				Typeflag: tar.TypeSymlink,
-				Linkname: entry.Linkname,
-			})
-			require.NoError(t, err)
-		}
+		writeEntryToTar(t, tarWriter, entry)
 	}
 }
 
+func writeEntryToTar(
+	t *testing.T,
+	tarWriter *tar.Writer,
+	entry ArchiveEntry,
+) {
+	t.Helper()
+	mode := getEntryMode(entry)
+
+	switch entry.Type {
+	case tar.TypeDir:
+		writeTarDir(t, tarWriter, entry.Name, mode)
+	case tar.TypeReg:
+		writeTarFile(t, tarWriter, entry.Name, entry.Content, mode)
+	case tar.TypeSymlink:
+		writeTarSymlink(t, tarWriter, entry.Name, entry.Linkname, mode)
+	}
+}
+
+func getEntryMode(entry ArchiveEntry) int64 {
+	if entry.Mode == noMode {
+		switch entry.Type {
+		case tar.TypeDir:
+			return defaultDirMode
+		case tar.TypeSymlink:
+			return defaultSymlinkMode
+		default:
+			return defaultFileMode
+		}
+	}
+	return entry.Mode
+}
+
+func writeTarDir(t *testing.T, w *tar.Writer, name string, mode int64) {
+	t.Helper()
+	err := w.WriteHeader(&tar.Header{
+		Name:     name,
+		Mode:     mode,
+		Typeflag: tar.TypeDir,
+	})
+	require.NoError(t, err)
+}
+
+func writeTarFile(
+	t *testing.T,
+	w *tar.Writer,
+	name, content string,
+	mode int64,
+) {
+	t.Helper()
+	contentBytes := []byte(content)
+	err := w.WriteHeader(&tar.Header{
+		Name:     name,
+		Mode:     mode,
+		Size:     int64(len(contentBytes)),
+		Typeflag: tar.TypeReg,
+	})
+	require.NoError(t, err)
+	_, err = w.Write(contentBytes)
+	require.NoError(t, err)
+}
+
+func writeTarSymlink(
+	t *testing.T,
+	w *tar.Writer,
+	name, linkname string,
+	mode int64,
+) {
+	t.Helper()
+	err := w.WriteHeader(&tar.Header{
+		Name:     name,
+		Mode:     mode,
+		Typeflag: tar.TypeSymlink,
+		Linkname: linkname,
+	})
+	require.NoError(t, err)
+}
+
 // createZip creates a zip file from a list of ArchiveEntry structs.
-// Note: ZIP does not support symlinks, so ArchiveEntry with Type tar.TypeSymlink will be skipped.
+// Note: ZIP does not support symlinks, entries with Type
+// tar.TypeSymlink will be skipped.
 func createZip(t *testing.T, zipPath string, entries []ArchiveEntry) {
 	t.Helper()
 
@@ -111,30 +160,53 @@ func createZip(t *testing.T, zipPath string, entries []ArchiveEntry) {
 	defer zipWriter.Close()
 
 	for _, entry := range entries {
-		switch entry.Type {
-		case tar.TypeDir:
-			// Directories in zip must end with /
-			name := entry.Name
-			if name[len(name)-1] != '/' {
-				name += "/"
-			}
-			_, err = zipWriter.Create(name)
-			require.NoError(t, err)
-
-		case tar.TypeReg:
-			writer, err := zipWriter.Create(entry.Name)
-			require.NoError(t, err)
-			_, err = writer.Write([]byte(entry.Content))
-			require.NoError(t, err)
-
-		case tar.TypeSymlink:
-			// ZIP does not support symlinks, skip
-			t.Logf("Skipping symlink entry %s (ZIP does not support symlinks)", entry.Name)
-		}
+		writeEntryToZip(t, zipWriter, entry)
 	}
 }
 
-// verifyExtractedFile checks that a file exists and has the expected content
+func writeEntryToZip(
+	t *testing.T,
+	zipWriter *zip.Writer,
+	entry ArchiveEntry,
+) {
+	t.Helper()
+
+	switch entry.Type {
+	case tar.TypeDir:
+		writeZipDir(t, zipWriter, entry.Name)
+	case tar.TypeReg:
+		writeZipFile(t, zipWriter, entry.Name, entry.Content)
+	case tar.TypeSymlink:
+		logSkippedSymlink(t, entry.Name)
+	}
+}
+
+func writeZipDir(t *testing.T, w *zip.Writer, name string) {
+	t.Helper()
+	if name[len(name)-lastCharIndex] != '/' {
+		name += "/"
+	}
+	_, err := w.Create(name)
+	require.NoError(t, err)
+}
+
+func writeZipFile(t *testing.T, w *zip.Writer, name, content string) {
+	t.Helper()
+	writer, err := w.Create(name)
+	require.NoError(t, err)
+	_, err = writer.Write([]byte(content))
+	require.NoError(t, err)
+}
+
+func logSkippedSymlink(t *testing.T, name string) {
+	t.Helper()
+	t.Logf(
+		"Skipping symlink entry %s (ZIP does not support symlinks)",
+		name,
+	)
+}
+
+// verifyExtractedFile checks file exists and has expected content
 func verifyExtractedFile(t *testing.T, path, expectedContent string) {
 	t.Helper()
 	require.FileExists(t, path)
@@ -143,18 +215,21 @@ func verifyExtractedFile(t *testing.T, path, expectedContent string) {
 	require.Equal(t, expectedContent, string(content))
 }
 
-// verifyExtractedSymlink checks that a symlink exists and points to the expected target
+// verifyExtractedSymlink checks that a symlink exists and points
+// to the expected target
 func verifyExtractedSymlink(t *testing.T, path, expectedTarget string) {
 	t.Helper()
 	linkInfo, err := os.Lstat(path)
 	require.NoError(t, err, "Symlink should exist")
-	require.True(t, linkInfo.Mode()&os.ModeSymlink != 0, "Should be a symlink")
+	require.True(t, linkInfo.Mode()&os.ModeSymlink != 0,
+		"Should be a symlink")
 	target, err := os.Readlink(path)
 	require.NoError(t, err)
 	require.Equal(t, expectedTarget, target)
 }
 
-// setupTestDir creates a temporary directory and returns it along with a cleanup function
+// setupTestDir creates a temporary directory and returns it
+// along with a cleanup function
 func setupTestDir(t *testing.T) (tmpDir string, dstPath string) {
 	t.Helper()
 	tmpDir, err := os.MkdirTemp("", "vendir-archive-test")
@@ -162,7 +237,7 @@ func setupTestDir(t *testing.T) (tmpDir string, dstPath string) {
 	t.Cleanup(func() { os.RemoveAll(tmpDir) })
 
 	dstPath = filepath.Join(tmpDir, "extracted")
-	require.NoError(t, os.MkdirAll(dstPath, 0755))
+	require.NoError(t, os.MkdirAll(dstPath, defaultDirMode))
 
 	return tmpDir, dstPath
 }
@@ -171,25 +246,32 @@ func TestArchiveUnpackTgz(t *testing.T) {
 	t.Run("Unpack tgz file with dir, file and symlink", func(t *testing.T) {
 		tmpDir, dstPath := setupTestDir(t)
 
-		// Create a synthetic tgz file without symlinks
 		tgzPath := filepath.Join(tmpDir, "test.tgz")
 		createTar(t, tgzPath, []ArchiveEntry{
 			{Name: "testdir/", Type: tar.TypeDir},
-			{Name: "testdir/file.txt", Type: tar.TypeReg, Content: "hello world"},
-			{Name: "testdir/subdir/nested.txt", Type: tar.TypeReg, Content: "nested content"},
-			{Name: "testdir/link", Type: tar.TypeSymlink, Linkname: "file.txt"},
+			{Name: "testdir/file.txt", Type: tar.TypeReg,
+				Content: "hello world"},
+			{Name: "testdir/subdir/nested.txt", Type: tar.TypeReg,
+				Content: "nested content"},
+			{Name: "testdir/link", Type: tar.TypeSymlink,
+				Linkname: "file.txt"},
 		}, TarOptions{Gzip: true})
 
-		unpacked, err := ctlfetch.NewArchive(tgzPath, false, "").Unpack(dstPath)
+		unpacked, err := ctlfetch.NewArchive(
+			tgzPath, false, "").Unpack(dstPath)
 		require.NoError(t, err, "Unpacking should not return an error")
-		require.True(t, unpacked, "Unpacking should return true indicating success")
+		require.True(t, unpacked,
+			"Unpacking should return true indicating success")
 
-		// Verify that files were extracted
-		verifyExtractedFile(t, filepath.Join(dstPath, "testdir", "file.txt"), "hello world")
-		verifyExtractedFile(t, filepath.Join(dstPath, "testdir", "subdir", "nested.txt"), "nested content")
-
-		// Verify the symlink was created
-		verifyExtractedSymlink(t, filepath.Join(dstPath, "testdir", "link"), "file.txt")
+		verifyExtractedFile(t,
+			filepath.Join(dstPath, "testdir", "file.txt"),
+			"hello world")
+		verifyExtractedFile(t,
+			filepath.Join(dstPath, "testdir", "subdir", "nested.txt"),
+			"nested content")
+		verifyExtractedSymlink(t,
+			filepath.Join(dstPath, "testdir", "link"),
+			"file.txt")
 	})
 }
 
@@ -197,25 +279,32 @@ func TestArchiveUnpackTar(t *testing.T) {
 	t.Run("Unpack tar file dir, file and symlink", func(t *testing.T) {
 		tmpDir, dstPath := setupTestDir(t)
 
-		// Create a synthetic tgz file without symlinks
 		tarPath := filepath.Join(tmpDir, "test.tar")
 		createTar(t, tarPath, []ArchiveEntry{
 			{Name: "testdir/", Type: tar.TypeDir},
-			{Name: "testdir/file.txt", Type: tar.TypeReg, Content: "hello world"},
-			{Name: "testdir/subdir/nested.txt", Type: tar.TypeReg, Content: "nested content"},
-			{Name: "testdir/link", Type: tar.TypeSymlink, Linkname: "file.txt"},
+			{Name: "testdir/file.txt", Type: tar.TypeReg,
+				Content: "hello world"},
+			{Name: "testdir/subdir/nested.txt", Type: tar.TypeReg,
+				Content: "nested content"},
+			{Name: "testdir/link", Type: tar.TypeSymlink,
+				Linkname: "file.txt"},
 		}, TarOptions{Gzip: false})
 
-		unpacked, err := ctlfetch.NewArchive(tarPath, false, "").Unpack(dstPath)
+		unpacked, err := ctlfetch.NewArchive(
+			tarPath, false, "").Unpack(dstPath)
 		require.NoError(t, err, "Unpacking should not return an error")
-		require.True(t, unpacked, "Unpacking should return true indicating success")
+		require.True(t, unpacked,
+			"Unpacking should return true indicating success")
 
-		// Verify that files were extracted
-		verifyExtractedFile(t, filepath.Join(dstPath, "testdir", "file.txt"), "hello world")
-		verifyExtractedFile(t, filepath.Join(dstPath, "testdir", "subdir", "nested.txt"), "nested content")
-
-		// Verify the symlink was created
-		verifyExtractedSymlink(t, filepath.Join(dstPath, "testdir", "link"), "file.txt")
+		verifyExtractedFile(t,
+			filepath.Join(dstPath, "testdir", "file.txt"),
+			"hello world")
+		verifyExtractedFile(t,
+			filepath.Join(dstPath, "testdir", "subdir", "nested.txt"),
+			"nested content")
+		verifyExtractedSymlink(t,
+			filepath.Join(dstPath, "testdir", "link"),
+			"file.txt")
 	})
 }
 
@@ -223,20 +312,26 @@ func TestArchiveUnpackZip(t *testing.T) {
 	t.Run("Unpack zip file without symlinks succeeds", func(t *testing.T) {
 		tmpDir, dstPath := setupTestDir(t)
 
-		// Create a synthetic zip file
 		zipPath := filepath.Join(tmpDir, "test.zip")
 		createZip(t, zipPath, []ArchiveEntry{
 			{Name: "testdir/", Type: tar.TypeDir},
-			{Name: "testdir/file.txt", Type: tar.TypeReg, Content: "hello world"},
-			{Name: "testdir/subdir/nested.txt", Type: tar.TypeReg, Content: "nested content"},
+			{Name: "testdir/file.txt", Type: tar.TypeReg,
+				Content: "hello world"},
+			{Name: "testdir/subdir/nested.txt", Type: tar.TypeReg,
+				Content: "nested content"},
 		})
 
-		unpacked, err := ctlfetch.NewArchive(zipPath, false, "").Unpack(dstPath)
+		unpacked, err := ctlfetch.NewArchive(
+			zipPath, false, "").Unpack(dstPath)
 		require.NoError(t, err, "Unpacking should not return an error")
-		require.True(t, unpacked, "Unpacking should return true indicating success")
+		require.True(t, unpacked,
+			"Unpacking should return true indicating success")
 
-		// Verify that files were extracted
-		verifyExtractedFile(t, filepath.Join(dstPath, "testdir", "file.txt"), "hello world")
-		verifyExtractedFile(t, filepath.Join(dstPath, "testdir", "subdir", "nested.txt"), "nested content")
+		verifyExtractedFile(t,
+			filepath.Join(dstPath, "testdir", "file.txt"),
+			"hello world")
+		verifyExtractedFile(t,
+			filepath.Join(dstPath, "testdir", "subdir", "nested.txt"),
+			"nested content")
 	})
 }

--- a/pkg/vendir/fetch/archive_test.go
+++ b/pkg/vendir/fetch/archive_test.go
@@ -1,0 +1,242 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package fetch_test
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	ctlfetch "carvel.dev/vendir/pkg/vendir/fetch"
+	"github.com/stretchr/testify/require"
+)
+
+// ArchiveEntry represents a simplified entry for creating archives in tests
+type ArchiveEntry struct {
+	Name     string // Path/name of the entry in the archive
+	Type     byte   // Type of entry: tar.TypeReg, tar.TypeDir, or tar.TypeSymlink
+	Content  string // Content for regular files (ignored for dirs/symlinks)
+	Linkname string // Target for symlinks (ignored for files/dirs)
+	Mode     int64  // File mode (optional, defaults will be applied)
+}
+
+// TarOptions contains options for creating tar archives
+type TarOptions struct {
+	Gzip bool // Whether to compress the archive with gzip
+}
+
+// createTar creates a tar file from a list of ArchiveEntry structs.
+// This is a reusable helper for creating test archives with various contents.
+// Use opts.Gzip to create a gzip-compressed tar.gz file.
+func createTar(t *testing.T, tarPath string, entries []ArchiveEntry, opts TarOptions) {
+	t.Helper()
+
+	file, err := os.Create(tarPath)
+	require.NoError(t, err)
+	defer file.Close()
+
+	var tarWriter *tar.Writer
+	var gzipWriter *gzip.Writer
+
+	if opts.Gzip {
+		gzipWriter = gzip.NewWriter(file)
+		defer gzipWriter.Close()
+		tarWriter = tar.NewWriter(gzipWriter)
+	} else {
+		tarWriter = tar.NewWriter(file)
+	}
+	defer tarWriter.Close()
+
+	for _, entry := range entries {
+		mode := entry.Mode
+		if mode == 0 {
+			// Apply default modes based on type
+			switch entry.Type {
+			case tar.TypeDir:
+				mode = 0755
+			case tar.TypeSymlink:
+				mode = 0777
+			default:
+				mode = 0644
+			}
+		}
+
+		switch entry.Type {
+		case tar.TypeDir:
+			err = tarWriter.WriteHeader(&tar.Header{
+				Name:     entry.Name,
+				Mode:     mode,
+				Typeflag: tar.TypeDir,
+			})
+			require.NoError(t, err)
+
+		case tar.TypeReg:
+			content := []byte(entry.Content)
+			err = tarWriter.WriteHeader(&tar.Header{
+				Name:     entry.Name,
+				Mode:     mode,
+				Size:     int64(len(content)),
+				Typeflag: tar.TypeReg,
+			})
+			require.NoError(t, err)
+			_, err = tarWriter.Write(content)
+			require.NoError(t, err)
+
+		case tar.TypeSymlink:
+			err = tarWriter.WriteHeader(&tar.Header{
+				Name:     entry.Name,
+				Mode:     mode,
+				Typeflag: tar.TypeSymlink,
+				Linkname: entry.Linkname,
+			})
+			require.NoError(t, err)
+		}
+	}
+}
+
+// createZip creates a zip file from a list of ArchiveEntry structs.
+// Note: ZIP does not support symlinks, so ArchiveEntry with Type tar.TypeSymlink will be skipped.
+func createZip(t *testing.T, zipPath string, entries []ArchiveEntry) {
+	t.Helper()
+
+	file, err := os.Create(zipPath)
+	require.NoError(t, err)
+	defer file.Close()
+
+	zipWriter := zip.NewWriter(file)
+	defer zipWriter.Close()
+
+	for _, entry := range entries {
+		switch entry.Type {
+		case tar.TypeDir:
+			// Directories in zip must end with /
+			name := entry.Name
+			if name[len(name)-1] != '/' {
+				name += "/"
+			}
+			_, err = zipWriter.Create(name)
+			require.NoError(t, err)
+
+		case tar.TypeReg:
+			writer, err := zipWriter.Create(entry.Name)
+			require.NoError(t, err)
+			_, err = writer.Write([]byte(entry.Content))
+			require.NoError(t, err)
+
+		case tar.TypeSymlink:
+			// ZIP does not support symlinks, skip
+			t.Logf("Skipping symlink entry %s (ZIP does not support symlinks)", entry.Name)
+		}
+	}
+}
+
+// verifyExtractedFile checks that a file exists and has the expected content
+func verifyExtractedFile(t *testing.T, path, expectedContent string) {
+	t.Helper()
+	require.FileExists(t, path)
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, expectedContent, string(content))
+}
+
+// verifyExtractedSymlink checks that a symlink exists and points to the expected target
+func verifyExtractedSymlink(t *testing.T, path, expectedTarget string) {
+	t.Helper()
+	linkInfo, err := os.Lstat(path)
+	require.NoError(t, err, "Symlink should exist")
+	require.True(t, linkInfo.Mode()&os.ModeSymlink != 0, "Should be a symlink")
+	target, err := os.Readlink(path)
+	require.NoError(t, err)
+	require.Equal(t, expectedTarget, target)
+}
+
+// setupTestDir creates a temporary directory and returns it along with a cleanup function
+func setupTestDir(t *testing.T) (tmpDir string, dstPath string) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "vendir-archive-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	dstPath = filepath.Join(tmpDir, "extracted")
+	require.NoError(t, os.MkdirAll(dstPath, 0755))
+
+	return tmpDir, dstPath
+}
+
+func TestArchiveUnpackTgz(t *testing.T) {
+	t.Run("Unpack tgz file with dir, file and symlink", func(t *testing.T) {
+		tmpDir, dstPath := setupTestDir(t)
+
+		// Create a synthetic tgz file without symlinks
+		tgzPath := filepath.Join(tmpDir, "test.tgz")
+		createTar(t, tgzPath, []ArchiveEntry{
+			{Name: "testdir/", Type: tar.TypeDir},
+			{Name: "testdir/file.txt", Type: tar.TypeReg, Content: "hello world"},
+			{Name: "testdir/subdir/nested.txt", Type: tar.TypeReg, Content: "nested content"},
+			{Name: "testdir/link", Type: tar.TypeSymlink, Linkname: "file.txt"},
+		}, TarOptions{Gzip: true})
+
+		unpacked, err := ctlfetch.NewArchive(tgzPath, false, "").Unpack(dstPath)
+		require.NoError(t, err, "Unpacking should not return an error")
+		require.True(t, unpacked, "Unpacking should return true indicating success")
+
+		// Verify that files were extracted
+		verifyExtractedFile(t, filepath.Join(dstPath, "testdir", "file.txt"), "hello world")
+		verifyExtractedFile(t, filepath.Join(dstPath, "testdir", "subdir", "nested.txt"), "nested content")
+
+		// Verify the symlink was created
+		verifyExtractedSymlink(t, filepath.Join(dstPath, "testdir", "link"), "file.txt")
+	})
+}
+
+func TestArchiveUnpackTar(t *testing.T) {
+	t.Run("Unpack tar file dir, file and symlink", func(t *testing.T) {
+		tmpDir, dstPath := setupTestDir(t)
+
+		// Create a synthetic tgz file without symlinks
+		tarPath := filepath.Join(tmpDir, "test.tar")
+		createTar(t, tarPath, []ArchiveEntry{
+			{Name: "testdir/", Type: tar.TypeDir},
+			{Name: "testdir/file.txt", Type: tar.TypeReg, Content: "hello world"},
+			{Name: "testdir/subdir/nested.txt", Type: tar.TypeReg, Content: "nested content"},
+			{Name: "testdir/link", Type: tar.TypeSymlink, Linkname: "file.txt"},
+		}, TarOptions{Gzip: false})
+
+		unpacked, err := ctlfetch.NewArchive(tarPath, false, "").Unpack(dstPath)
+		require.NoError(t, err, "Unpacking should not return an error")
+		require.True(t, unpacked, "Unpacking should return true indicating success")
+
+		// Verify that files were extracted
+		verifyExtractedFile(t, filepath.Join(dstPath, "testdir", "file.txt"), "hello world")
+		verifyExtractedFile(t, filepath.Join(dstPath, "testdir", "subdir", "nested.txt"), "nested content")
+
+		// Verify the symlink was created
+		verifyExtractedSymlink(t, filepath.Join(dstPath, "testdir", "link"), "file.txt")
+	})
+}
+
+func TestArchiveUnpackZip(t *testing.T) {
+	t.Run("Unpack zip file without symlinks succeeds", func(t *testing.T) {
+		tmpDir, dstPath := setupTestDir(t)
+
+		// Create a synthetic zip file
+		zipPath := filepath.Join(tmpDir, "test.zip")
+		createZip(t, zipPath, []ArchiveEntry{
+			{Name: "testdir/", Type: tar.TypeDir},
+			{Name: "testdir/file.txt", Type: tar.TypeReg, Content: "hello world"},
+			{Name: "testdir/subdir/nested.txt", Type: tar.TypeReg, Content: "nested content"},
+		})
+
+		unpacked, err := ctlfetch.NewArchive(zipPath, false, "").Unpack(dstPath)
+		require.NoError(t, err, "Unpacking should not return an error")
+		require.True(t, unpacked, "Unpacking should return true indicating success")
+
+		// Verify that files were extracted
+		verifyExtractedFile(t, filepath.Join(dstPath, "testdir", "file.txt"), "hello world")
+		verifyExtractedFile(t, filepath.Join(dstPath, "testdir", "subdir", "nested.txt"), "nested content")
+	})
+}


### PR DESCRIPTION
## description

adds support for symlink tar entry to extract as symlink

added archive unit tests with synthetic archive files generation

Fixes https://github.com/carvel-dev/vendir/issues/395

## symbolic links checks

symbolic links still are verified after the unarchiving in the other parts of the sync, so supporting symlinks should not create new security issue.

Created test release here with some test archives: https://github.com/DocX/vendir/releases/tag/test-release

### Symbolic link to other file in archive:

```yaml
apiVersion: vendir.k14s.io/v1alpha1
kind: Config
directories:
  - path: vendor
    contents:
      # unpacks archive that contains symlinks
      - path: github.com/docx/vendir/test-symlink
        githubRelease:
          slug: docx/vendir
          tag: test-release
          checksums:
            test-archive.tar.gz: 7ddbd22239c359e79d2788261d0802b6926005b6540cd52204c89a1084798128
            test-archive-invalid-symlink.tar.gz: 9997b306d6352dd33f239e38c00db8b3d2f9ade291116c047e973c39cff9d524
            test-archive-external-symlink.tar.gz: 0982e0328e1d5a08d3d56941d5b3bd1c30e4abb318d9895da3d9d6117b6960de
          unpackArchive:
            path: test-archive.tar.gz
```

Output
```
$ vendir sync
Fetching: vendor + github.com/docx/vendir/test-symlink (github release docx/vendir@test-release)

$ ls -laR vendor
vendor/github.com/docx/vendir/test-symlink/test-archive:
total 24
drwx------  6 lukasdolezal  staff  192 Feb  4 12:11 .
drwx------  3 lukasdolezal  staff   96 Feb  4 12:11 ..
-rw-r--r--  1 lukasdolezal  staff   28 Feb  4 12:11 file1.txt
-rw-r--r--  1 lukasdolezal  staff   29 Feb  4 12:11 file2.txt
-rw-r--r--  1 lukasdolezal  staff   28 Feb  4 12:11 file3.txt
lrwxr-xr-x  1 lukasdolezal  staff    9 Feb  4 12:11 link-to-file1.txt -> file1.txt
```

### Symbolic link to non existing file outside the archive:
```yaml
apiVersion: vendir.k14s.io/v1alpha1
kind: Config
directories:
  - path: vendor
    contents:
      # fails to unpacks archive that contains symlinks that point outside of archive (not existing)
      - path: github.com/docx/vendir/test-invalid-symlink
        githubRelease:
          slug: docx/vendir
          tag: test-release
          checksums:
            test-archive.tar.gz: 7ddbd22239c359e79d2788261d0802b6926005b6540cd52204c89a1084798128
            test-archive-invalid-symlink.tar.gz: 9997b306d6352dd33f239e38c00db8b3d2f9ade291116c047e973c39cff9d524
            test-archive-external-symlink.tar.gz: 0982e0328e1d5a08d3d56941d5b3bd1c30e4abb318d9895da3d9d6117b6960de
          unpackArchive:
            path: test-archive-invalid-symlink.tar.gz
```

Output
```
$ vendir sync
Fetching: vendor + github.com/docx/vendir/test-invalid-symlink (github release docx/vendir@test-release)

vendir: Error: Unable to resolve symlink: lstat /private/tmp/external-file.txt: no such file or directory

$ ls -laR vendor
vendor/github.com/docx/vendir/test-invalid-symlink/test-archive-invalid:
total 16
drwx------  5 lukasdolezal  staff  160 Feb  4 12:11 .
drwx------  3 lukasdolezal  staff   96 Feb  4 12:11 ..
lrwxr-xr-x  1 lukasdolezal  staff   22 Feb  4 12:11 external-link.txt -> /tmp/external-file.txt
-rw-r--r--  1 lukasdolezal  staff   20 Feb  4 12:11 file1.txt
-rw-r--r--  1 lukasdolezal  staff   18 Feb  4 12:11 file2.txt
```

### Symbolic link to external system file (`/etc/hosts`)
```yaml
apiVersion: vendir.k14s.io/v1alpha1
kind: Config
directories:
  - path: vendor
    contents:
      # fails to unpacks archive that contains symlinks that point outside of archive (/etc/hosts)
      - path: github.com/docx/vendir/test-external-symlink
        githubRelease:
          slug: docx/vendir
          tag: test-release
          checksums:
            test-archive.tar.gz: 7ddbd22239c359e79d2788261d0802b6926005b6540cd52204c89a1084798128
            test-archive-invalid-symlink.tar.gz: 9997b306d6352dd33f239e38c00db8b3d2f9ade291116c047e973c39cff9d524
            test-archive-external-symlink.tar.gz: 0982e0328e1d5a08d3d56941d5b3bd1c30e4abb318d9895da3d9d6117b6960de
          unpackArchive:
            path: test-archive-external-symlink.tar.gz
```

Output:
```
$ vendir sync
Fetching: vendor + github.com/docx/vendir/test-external-symlink (github release docx/vendir@test-release)

vendir: Error: Invalid symlink found to outside parent directory: "/private/etc/hosts"

$ ls -laR vendor
vendor/github.com/docx/vendir/test-external-symlink:
total 24
drwx------  6 lukasdolezal  staff  192 Feb  4 12:17 .
drwx------  3 lukasdolezal  staff   96 Feb  4 12:17 ..
lrwxr-xr-x  1 lukasdolezal  staff   10 Feb  4 12:17 external-symlink -> /etc/hosts
-rw-r--r--  1 lukasdolezal  staff   20 Feb  4 12:17 file1.txt
-rw-r--r--  1 lukasdolezal  staff   20 Feb  4 12:17 file2.txt
-rw-r--r--  1 lukasdolezal  staff   20 Feb  4 12:17 file3.txt
```


