### PR TITLE
Bump golang to 1.25.7 and imgpkg to v0.47.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module carvel.dev/vendir
 
-go 1.25.6
+go 1.25.7
 
 require (
-	carvel.dev/imgpkg v0.47.1
+	carvel.dev/imgpkg v0.47.2
 	github.com/bmatcuk/doublestar v1.2.1
 	github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4
 	github.com/cppforlife/cobrautil v0.0.0-20221021151949-d60711905d65

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-carvel.dev/imgpkg v0.47.1 h1:5hJu20JeAr3HGGRCDi2ydlKVEhhF6bq0EebdB9Eql2I=
-carvel.dev/imgpkg v0.47.1/go.mod h1:f/LUtEuUHTdAeFfDcRa2MTwfXbQe6cq+kzzlQF0In6w=
+carvel.dev/imgpkg v0.47.2 h1:rEqC/Saf3PHmHEhaJMcqZLjatALTPD9VmBXuUYqPaGk=
+carvel.dev/imgpkg v0.47.2/go.mod h1:3vIZkREPq+i7s8eloLEv5+t+LzzC49uv9xeh+KLADdk=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go/compute/metadata v0.7.0 h1:PBWF+iiAerVNe8UCHxdOt6eHLVc3ydFeOCw78U8ytSU=
 cloud.google.com/go/compute/metadata v0.7.0/go.mod h1:j5MvL9PprKL39t166CoB1uVHfQMs4tFQZZcKwksXUjo=

--- a/pkg/vendir/fetch/archive_test.go
+++ b/pkg/vendir/fetch/archive_test.go
@@ -84,6 +84,8 @@ func writeEntryToTar(
 		writeTarFile(t, tarWriter, entry.Name, entry.Content, mode)
 	case tar.TypeSymlink:
 		writeTarSymlink(t, tarWriter, entry.Name, entry.Linkname, mode)
+	default:
+		t.Fatalf("Unknown Entry type %c for entry '%s'", entry.Type, entry.Name)
 	}
 }
 
@@ -178,6 +180,8 @@ func writeEntryToZip(
 		writeZipFile(t, zipWriter, entry.Name, entry.Content)
 	case tar.TypeSymlink:
 		logSkippedSymlink(t, entry.Name)
+	default:
+		t.Fatalf("Unknown Entry type %c for entry '%s'", entry.Type, entry.Name)
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,5 @@
-# carvel.dev/imgpkg v0.47.1
-## explicit; go 1.25.6
+# carvel.dev/imgpkg v0.47.2
+## explicit; go 1.25.7
 carvel.dev/imgpkg/pkg/imgpkg/bundle
 carvel.dev/imgpkg/pkg/imgpkg/image
 carvel.dev/imgpkg/pkg/imgpkg/imagedesc


### PR DESCRIPTION
Bumping golang to 1.25.7 to resolve the below CVEs:

```
┌─────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────┬─────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │        Fixed Version         │                          Title                          │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────┼─────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-68121 │ CRITICAL │ fixed  │ v1.25.6           │ 1.24.13, 1.25.7, 1.26.0-rc.3 │ crypto/tls: Unexpected session resumption in crypto/tls │
│         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-68121              │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────┴─────────────────────────────────────────────────────────┘
```