### PR TITLE
[v0.45.x] Update carvel-dev/semver to include stability-aware sorting fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.7
 require (
 	carvel.dev/imgpkg v0.47.2
 	github.com/bmatcuk/doublestar v1.2.1
-	github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4
+	github.com/carvel-dev/semver/v4 v4.0.1-0.20260413160702-f136b2e8bf02
 	github.com/cppforlife/cobrautil v0.0.0-20221021151949-d60711905d65
 	github.com/cppforlife/go-cli-ui v0.0.0-20220425131040-94f26b16bc14
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.9.1 h1:50sS0RWhGpW/
 github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.9.1/go.mod h1:ErZOtbzuHabipRTDTor0inoRlYwbsV1ovwSxjGs/uJo=
 github.com/bmatcuk/doublestar v1.2.1 h1:eetYiv8DDYOZcBADY+pRvRytf3Dlz1FhnpvL2FsClBc=
 github.com/bmatcuk/doublestar v1.2.1/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
-github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4 h1:F4rZiMGZyC66j9VB7doVOE4tFHF1yNEihQlOuht4jmM=
-github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4/go.mod h1:4cFTBLAr/U11ykiEEQMccu4uJ1i0GS+atJmeETHCFtI=
+github.com/carvel-dev/semver/v4 v4.0.1-0.20260413160702-f136b2e8bf02 h1:LP+GFDwgIBQFld1EhQt3UaN1typu03sqU3eWCKM5Isk=
+github.com/carvel-dev/semver/v4 v4.0.1-0.20260413160702-f136b2e8bf02/go.mod h1:4cFTBLAr/U11ykiEEQMccu4uJ1i0GS+atJmeETHCFtI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb/v3 v3.1.7 h1:2FsIW307kt7A/rz/ZI2lvPO+v3wKazzE4K/0LtTWsOI=
 github.com/cheggaaa/pb/v3 v3.1.7/go.mod h1:/Ji89zfVPeC/u5j8ukD0MBPHt2bzTYp74lQ7KlgFWTQ=

--- a/vendor/github.com/carvel-dev/semver/v4/semver.go
+++ b/vendor/github.com/carvel-dev/semver/v4/semver.go
@@ -3,6 +3,7 @@ package semver
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -18,6 +19,8 @@ const (
 	prereleaseType versionExtType = "PreRelease"
 	buildmetaType                 = "BuildMeta"
 )
+
+var chunkRegexp = regexp.MustCompile(`(\d+|\D+)`)
 
 // SpecVersion is the latest fully supported spec version of semver
 var SpecVersion = Version{
@@ -193,10 +196,10 @@ func (v Version) Validate() error {
 
 	for _, build := range v.Build {
 		if len(build.VersionStr) == 0 {
-			return fmt.Errorf("Build meta data can not be empty %q", build)
+			return fmt.Errorf("Build meta data can not be empty %q", build.VersionStr)
 		}
 		if !containsOnly(build.VersionStr, alphanum) {
-			return fmt.Errorf("Invalid character(s) found in build meta data %q", build)
+			return fmt.Errorf("Invalid character(s) found in build meta data %q", build.VersionStr)
 		}
 	}
 
@@ -285,9 +288,7 @@ func Parse(s string) (Version, error) {
 		return Version{}, err
 	}
 
-	v := Version{}
-	v.Major = major
-	v.Minor = minor
+	v := Version{Major: major, Minor: minor}
 
 	var build, prerelease []string
 	patchStr := parts[2]
@@ -368,10 +369,8 @@ func (ve BuildMeta) Compare(o BuildMeta) int {
 	for ; i < len(ve) && i < len(o); i++ {
 		if comp := ve[i].Compare(o[i]); comp == 0 {
 			continue
-		} else if comp == 1 {
-			return 1
 		} else {
-			return -1
+			return comp
 		}
 	}
 
@@ -399,10 +398,8 @@ func (ve PRVersion) Compare(o PRVersion) int {
 	for ; i < len(ve) && i < len(o); i++ {
 		if comp := ve[i].Compare(o[i]); comp == 0 {
 			continue
-		} else if comp == 1 {
-			return 1
 		} else {
-			return -1
+			return comp
 		}
 	}
 
@@ -431,7 +428,7 @@ func newVersionExtension(s string, extType versionExtType, additionalValidations
 
 		// Might never be hit, but just in case
 		if err != nil {
-			return versionExtension{}, err
+			return versionExtension{}, fmt.Errorf("Invalid numeric %s %q: %s", extType, s, err)
 		}
 		v.VersionNum = num
 		v.IsNum = true
@@ -450,7 +447,7 @@ func newVersionExtension(s string, extType versionExtType, additionalValidations
 	return v, nil
 }
 
-// IsNumeric checks if this extension is numeric is numeric
+// IsNumeric checks if this extension is numeric
 func (v versionExtension) IsNumeric() bool {
 	return v.IsNum
 }
@@ -460,27 +457,57 @@ func (v versionExtension) IsNumeric() bool {
 // 0 == v is equal to o
 // 1 == v is greater than o
 func (v versionExtension) Compare(o versionExtension) int {
-	if v.IsNum && !o.IsNum {
-		return -1
-	} else if !v.IsNum && o.IsNum {
-		return 1
-	} else if v.IsNum && o.IsNum {
+	// 1. Numeric vs Numeric: Standard comparison
+	if v.IsNum && o.IsNum {
 		if v.VersionNum == o.VersionNum {
 			return 0
-		} else if v.VersionNum > o.VersionNum {
-			return 1
-		} else {
-			return -1
 		}
-	} else { // both are Alphas
-		if v.VersionStr == o.VersionStr {
-			return 0
-		} else if v.VersionStr > o.VersionStr {
+		if v.VersionNum > o.VersionNum {
 			return 1
-		} else {
-			return -1
 		}
+		return -1
 	}
+
+	// 2. Handle Numeric vs Alphanumeric
+	// Identify segments containing pre-release identifiers (rc, alpha, beta).
+	isPreReleaseLabel := func(s string) bool {
+		lowerStr := strings.ToLower(s)
+		if !strings.Contains(lowerStr, "-") {
+			return false
+		}
+		// Only flag as pre-release if it contains these specific markers
+		preReleaseMarkers := []string{"alpha", "beta", "rc", "pre", "dev"}
+		for _, marker := range preReleaseMarkers {
+			if strings.Contains(lowerStr, marker) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if v.IsNum && !o.IsNum {
+		if isPreReleaseLabel(o.VersionStr) {
+			return 1 // Number wins against an RC/Alpha/Beta string
+		}
+		return -1 // Standard SemVer: Number < String
+	}
+	if !v.IsNum && o.IsNum {
+		if isPreReleaseLabel(v.VersionStr) {
+			return -1 // RC/Alpha/Beta string loses against a Number
+		}
+		return 1 // Standard SemVer: String > Number
+	}
+
+	// 3. Both are Alphanumeric
+	if v.VersionStr == o.VersionStr {
+		return 0
+	}
+
+	// Natural sort fallback for generic segments (e.g. "9-fips" vs "10-fips")
+	if naturalLess(v.VersionStr, o.VersionStr) {
+		return -1
+	}
+	return 1
 }
 
 func (v versionExtension) String() string {
@@ -507,8 +534,7 @@ func validatePRLeading0s(ext versionExtension) error {
 	return nil
 }
 
-// FinalizeVersion returns the major, minor and patch number only and discards
-// prerelease and build number.
+// FinalizeVersion returns the major, minor and patch number only.
 func FinalizeVersion(s string) (string, error) {
 	v, err := Parse(s)
 	if err != nil {
@@ -516,7 +542,34 @@ func FinalizeVersion(s string) (string, error) {
 	}
 	v.Pre = nil
 	v.Build = nil
+	return v.String(), nil
+}
 
-	finalVer := v.String()
-	return finalVer, nil
+func naturalLess(s1, s2 string) bool {
+	chunks1 := chunkRegexp.FindAllString(s1, -1)
+	chunks2 := chunkRegexp.FindAllString(s2, -1)
+
+	n := len(chunks1)
+	if len(chunks2) < n {
+		n = len(chunks2)
+	}
+
+	for i := 0; i < n; i++ {
+		c1, c2 := chunks1[i], chunks2[i]
+		if c1 == c2 {
+			continue
+		}
+
+		n1, err1 := strconv.ParseUint(c1, 10, 64)
+		n2, err2 := strconv.ParseUint(c2, 10, 64)
+
+		if err1 == nil && err2 == nil {
+			if n1 != n2 {
+				return n1 < n2
+			}
+			continue
+		}
+		return c1 < c2
+	}
+	return len(chunks1) < len(chunks2)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -176,7 +176,7 @@ github.com/awslabs/amazon-ecr-credential-helper/ecr-login/version
 # github.com/bmatcuk/doublestar v1.2.1
 ## explicit; go 1.12
 github.com/bmatcuk/doublestar
-# github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4
+# github.com/carvel-dev/semver/v4 v4.0.1-0.20260413160702-f136b2e8bf02
 ## explicit; go 1.14
 github.com/carvel-dev/semver/v4
 # github.com/cheggaaa/pb/v3 v3.1.7


### PR DESCRIPTION
**This PR updates carvel-dev/semver to the latest master**. 
This version includes : 
- Generic stability detection using internal hyphens.
- Fixes for sorting vendor-specific tags (e.g., v1.33 > v1.33-rc.2).
- Restored alphabetical precedence for standard pre-releases (e.g., pre < rc).

**FIx PRs from semver Repo :** 
https://github.com/carvel-dev/semver/pull/5
https://github.com/carvel-dev/semver/pull/6

**Test validation** 
```
go test -v ./pkg/vendir/versions/
=== RUN   TestSemverOrder
--- PASS: TestSemverOrder (0.00s)
=== RUN   TestSemverFilter
--- PASS: TestSemverFilter (0.00s)
=== RUN   TestSemverWithoutPrereleases
--- PASS: TestSemverWithoutPrereleases (0.00s)
=== RUN   TestSemverWithPrereleases
--- PASS: TestSemverWithPrereleases (0.00s)
=== RUN   TestSemverWithPrereleaseIdentifiers
--- PASS: TestSemverWithPrereleaseIdentifiers (0.00s)
=== RUN   TestSemverWithBuildMetadata
--- PASS: TestSemverWithBuildMetadata (0.00s)
=== RUN   TestSemverWithBuildMetadataAndConstraint
--- PASS: TestSemverWithBuildMetadataAndConstraint (0.00s)
=== RUN   TestHighestVersionWithConstraints
--- PASS: TestHighestVersionWithConstraints (0.00s)
PASS
ok      carvel.dev/vendir/pkg/vendir/versions   0.409s
```

**Manual Validation :** 
```
 ➜ vendir git:(bump-semver) ./vendir tools sort-semver -v 'v1.2.3+abc.9-fips v1.2.3+abc.10-fips' --prerelease;
Versions
v1.2.3+abc.9-fips  
v1.2.3+abc.10-fips  
Highest version: v1.2.3+abc.10-fips. Succeeded

➜  vendir git:(bump-semver) ./vendir tools sort-semver -v 'v1.2.3+abc.9 v1.2.3+abc.10'
Versions
v1.2.3+abc.9  
v1.2.3+abc.10  
Highest version: v1.2.3+abc.10. Succeeded

➜  vendir git:(bump-semver) ./vendir tools sort-semver -v '3.4.0+v1.33-rc.2 3.4.0+v1.33' --prerelease;
Versions
3.4.0+v1.33-rc.2  
3.4.0+v1.33  
Highest version: 3.4.0+v1.33. Succeeded
```