### PR TITLE
perf(git): optimize fetch for repos with many tags and branches

### DIFF
--- a/pkg/vendir/config/directory.go
+++ b/pkg/vendir/config/directory.go
@@ -73,6 +73,9 @@ type DirectoryContentsGit struct {
 	SkipInitSubmodules     bool `json:"skipInitSubmodules,omitempty"`
 	Depth                  int  `json:"depth,omitempty"`
 	ForceHTTPBasicAuth     bool `json:"forceHTTPBasicAuth,omitempty"`
+	// OriginalRef holds the ref before it was replaced by a locked SHA.
+	// Not serialized; set by Lock() to enable targeted fetching in locked mode.
+	OriginalRef string `json:"-" yaml:"-"`
 }
 
 type DirectoryContentsGitVerification struct {
@@ -348,6 +351,7 @@ func (c *DirectoryContentsGit) Lock(lockConfig *LockDirectoryContentsGit) error 
 	if len(lockConfig.SHA) == 0 {
 		return fmt.Errorf("Expected git SHA to be non-empty")
 	}
+	c.OriginalRef = c.Ref
 	c.Ref = lockConfig.SHA
 	return nil
 }

--- a/pkg/vendir/fetch/git/git.go
+++ b/pkg/vendir/fetch/git/git.go
@@ -166,30 +166,81 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 		}
 	}
 
-	// A targeted refspec fetch (named ref, or locked SHA with a known
-	// OriginalRef) doesn't need all tags. RefSelection needs them for semver
-	// matching, and a bare SHA with no OriginalRef can't be targeted at all.
-	tagOpt := "--tags"
-	if t.canTargetFetch() {
-		tagOpt = noTagsFlag
-	}
-	argss = append(argss, []string{"config", "remote.origin.tagOpt", tagOpt})
-
 	if bundle != "" {
 		argss = append(argss, []string{"bundle", "unbundle", bundle})
 	}
 
-	// When fetching a single named ref, git places it in FETCH_HEAD only —
-	// no local ref is created. Track this to use FETCH_HEAD for checkout.
-	fetchArgs, useFetchHead := t.targetedFetchArgs()
-	if t.opts.Depth > 0 {
-		fetchArgs = append(fetchArgs, "--depth", strconv.Itoa(t.opts.Depth))
-	}
-	argss = append(argss, fetchArgs)
-
 	err = t.cmdRunner.RunMultiple(argss, env, dstPath)
 	if err != nil {
 		return err
+	}
+
+	// Resolve an ambiguous ref (which may be either a branch or a tag) before
+	// constructing the refspec. This lets us preserve tags without fetching
+	// every tag in the repository.
+	refType := remoteRefUnknown
+	fetchRef := t.opts.Ref
+	if t.isLockedSHAWithNamedOriginal() {
+		fetchRef = t.opts.OriginalRef
+	}
+	if t.canTargetFetch() {
+		var err error
+		refType, err = t.remoteRefType(dstPath, fetchRef)
+		if err != nil {
+			return err
+		}
+	}
+
+	// RefSelection needs all tags for semver matching, and a bare SHA has no
+	// named ref to target. A targeted tag fetch explicitly creates just that
+	// tag; a targeted branch fetch uses Git's default auto-follow behavior,
+	// which fetches only tags reachable from the branch tip.
+	if !t.canTargetFetch() || refType == remoteRefUnknown ||
+		refType == remoteRefTag {
+		tagOpt := "--tags"
+		if t.canTargetFetch() {
+			tagOpt = noTagsFlag
+		}
+		_, _, err = t.cmdRunner.Run(
+			[]string{"config", "remote.origin.tagOpt", tagOpt}, nil, dstPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	// When fetching a single named ref, track the result in FETCH_HEAD for
+	// checkout. Branches/tags also get local refs to support bundle caching.
+	fetchArgs, useFetchHead := t.targetedFetchArgs(fetchRef, refType)
+	if t.opts.Depth > 0 {
+		fetchArgs = append(fetchArgs, "--depth", strconv.Itoa(t.opts.Depth))
+	}
+
+	_, _, err = t.cmdRunner.Run(fetchArgs, env, dstPath)
+	lockedFetchByOriginal := t.isLockedSHAWithNamedOriginal() &&
+		fetchRef != t.opts.Ref
+	if err != nil && lockedFetchByOriginal {
+		// The original ref may have been deleted or renamed since the config
+		// was locked. Fetching the locked object directly retains locked-sync
+		// behavior without requiring the old name to remain available.
+		fallbackArgs := []string{"fetch", "origin", t.opts.Ref, noTagsFlag}
+		if t.opts.Depth > 0 {
+			fallbackArgs = append(
+				fallbackArgs, "--depth", strconv.Itoa(t.opts.Depth),
+			)
+		}
+		_, _, err = t.cmdRunner.Run(fallbackArgs, env, dstPath)
+	}
+	if err != nil {
+		return err
+	}
+
+	if useFetchHead {
+		_, _, err = t.cmdRunner.Run([]string{
+			"update-ref", "refs/vendir/fetched", "FETCH_HEAD",
+		}, nil, dstPath)
+		if err != nil {
+			return err
+		}
 	}
 
 	ref, err := t.resolveRef(dstPath)
@@ -241,9 +292,13 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 }
 
 const (
-	noTagsFlag      = "--no-tags"
-	fetchHeadCommit = "FETCH_HEAD^{commit}"
-	originPrefix    = "origin/"
+	noTagsFlag         = "--no-tags"
+	fetchHeadCommit    = "FETCH_HEAD^{commit}"
+	originName         = "origin"
+	originPrefix       = originName + "/"
+	remoteHeadsPrefix  = "refs/heads/"
+	remoteTagsPrefix   = "refs/tags/"
+	minRemoteRefFields = 2
 )
 
 // isLockedSHAWithNamedOriginal reports whether Ref is a locked SHA with a
@@ -266,26 +321,71 @@ func (t *Git) canTargetFetch() bool {
 // targetedFetchArgs builds the "fetch origin ..." args for t.opts.Ref,
 // targeting a single named ref where possible. It reports whether the
 // result lands only in FETCH_HEAD (true) or creates a local ref (false).
-func (t *Git) targetedFetchArgs() ([]string, bool) {
-	fetchArgs := []string{"fetch", "origin"}
-	switch {
-	case strings.HasPrefix(t.opts.Ref, originPrefix):
-		// only fetch the exact remote branch we're seeking
-		branch := strings.TrimPrefix(t.opts.Ref, originPrefix)
-		return append(fetchArgs, branch, noTagsFlag), true
-	case len(t.opts.Ref) > 0 && !isHexSHA(t.opts.Ref):
-		// fetch only the named tag or branch; SHAs must use a full fetch
-		return append(fetchArgs, t.opts.Ref, noTagsFlag), true
-	case t.isLockedSHAWithNamedOriginal():
-		// locked mode: fetch by the original named ref to avoid a full fetch.
-		// origin/ is a local tracking prefix, not a valid remote refspec.
-		originalRef := strings.TrimPrefix(t.opts.OriginalRef, originPrefix)
-		return append(fetchArgs, originalRef, noTagsFlag), true
-	default:
+func (t *Git) targetedFetchArgs(
+	fetchRef string, refType remoteRefType,
+) ([]string, bool) {
+	fetchArgs := []string{"fetch", originName}
+	if !t.canTargetFetch() {
 		// no targeted ref available (e.g. RefSelection, or a bare SHA with
 		// no OriginalRef) — fall back to a full fetch of all branches/tags.
 		return fetchArgs, false
 	}
+
+	ref := strings.TrimPrefix(fetchRef, originPrefix)
+	ref = strings.TrimPrefix(ref, remoteHeadsPrefix)
+	ref = strings.TrimPrefix(ref, remoteTagsPrefix)
+	switch refType {
+	case remoteRefBranch:
+		return append(fetchArgs, ref+":refs/remotes/origin/"+ref), true
+	case remoteRefTag:
+		return append(
+			fetchArgs, remoteTagsPrefix+ref+":"+remoteTagsPrefix+ref,
+			noTagsFlag,
+		), true
+	default:
+		return append(fetchArgs, ref, noTagsFlag), true
+	}
+}
+
+type remoteRefType int
+
+const (
+	remoteRefUnknown remoteRefType = iota
+	remoteRefBranch
+	remoteRefTag
+)
+
+func (t *Git) remoteRefType(dstPath, ref string) (remoteRefType, error) {
+	normalizedRef := strings.TrimPrefix(ref, originPrefix)
+	switch {
+	case strings.HasPrefix(normalizedRef, remoteHeadsPrefix):
+		return remoteRefBranch, nil
+	case strings.HasPrefix(normalizedRef, remoteTagsPrefix):
+		return remoteRefTag, nil
+	}
+
+	out, _, err := t.cmdRunner.Run(
+		[]string{"ls-remote", "origin", normalizedRef}, nil, dstPath)
+	if err != nil {
+		return remoteRefUnknown, err
+	}
+
+	branchRef := remoteHeadsPrefix + normalizedRef
+	tagRef := remoteTagsPrefix + normalizedRef
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < minRemoteRefFields {
+			continue
+		}
+		switch fields[1] {
+		case branchRef:
+			return remoteRefBranch, nil
+		case tagRef:
+			return remoteRefTag, nil
+		}
+	}
+
+	return remoteRefUnknown, nil
 }
 
 func (t *Git) resolveRef(dstPath string) (string, error) {

--- a/pkg/vendir/fetch/git/git.go
+++ b/pkg/vendir/fetch/git/git.go
@@ -197,8 +197,11 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 			fetchArgs = append(fetchArgs, t.opts.Ref, "--no-tags")
 			useFetchHead = true
 		case isHexSHA(t.opts.Ref) && len(t.opts.OriginalRef) > 0 && !isHexSHA(t.opts.OriginalRef):
-			// locked mode: fetch by the original named ref so we avoid a full fetch
-			fetchArgs = append(fetchArgs, t.opts.OriginalRef, "--no-tags")
+			// locked mode: fetch by the original named ref so we avoid a full fetch.
+			// Strip any "origin/" prefix — that prefix is a local tracking convention
+			// and is not a valid remote refspec.
+			originalRef := strings.TrimPrefix(t.opts.OriginalRef, "origin/")
+			fetchArgs = append(fetchArgs, originalRef, "--no-tags")
 			useFetchHead = true
 		}
 		if t.opts.Depth > 0 {
@@ -216,7 +219,22 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 	if err != nil {
 		return err
 	}
-	if useFetchHead {
+
+	// In locked mode we fetch by the original named ref for performance, but must
+	// check out the exact locked SHA. Verify FETCH_HEAD resolves to that SHA before
+	// checkout so a force-pushed tag is caught early.
+	if useFetchHead && isHexSHA(t.opts.Ref) {
+		out, _, err := t.cmdRunner.Run([]string{"rev-parse", "FETCH_HEAD^{commit}"}, nil, dstPath)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(out) != t.opts.Ref {
+			return fmt.Errorf("Locked SHA %s does not match fetched commit %s — tag may have been moved", t.opts.Ref, strings.TrimSpace(out))
+		}
+		// Use the locked SHA for checkout so mutable refs (e.g. origin/main) don't
+		// cause locked syncs to track the branch tip instead of the pinned commit.
+		ref = t.opts.Ref
+	} else if useFetchHead {
 		ref = "FETCH_HEAD"
 	}
 
@@ -230,18 +248,6 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 	_, _, err = t.cmdRunner.Run([]string{"-c", "advice.detachedHead=false", "checkout", ref}, env, dstPath)
 	if err != nil {
 		return err
-	}
-
-	// In locked mode we fetched by the original named ref; verify the resulting
-	// commit matches the SHA recorded in the lock file.
-	if useFetchHead && isHexSHA(t.opts.Ref) {
-		out, _, err := t.cmdRunner.Run([]string{"rev-parse", "HEAD"}, nil, dstPath)
-		if err != nil {
-			return err
-		}
-		if strings.TrimSpace(out) != t.opts.Ref {
-			return fmt.Errorf("Locked SHA %s does not match fetched commit %s — tag may have been moved", t.opts.Ref, strings.TrimSpace(out))
-		}
 	}
 
 	if !t.opts.SkipInitSubmodules {
@@ -284,14 +290,14 @@ func (t *Git) tags(dstPath string) ([]string, error) {
 }
 
 // isHexSHA reports whether s looks like a full or abbreviated git commit SHA
-// (7–40 lowercase hex characters). SHAs cannot be fetched by refspec name and
-// require a full fetch to be resolved.
+// (7–40 hex characters, case-insensitive). SHAs cannot be fetched by refspec
+// name and require a full fetch to be resolved.
 func isHexSHA(s string) bool {
 	if len(s) < 7 || len(s) > 40 {
 		return false
 	}
 	for _, c := range s {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
 			return false
 		}
 	}

--- a/pkg/vendir/fetch/git/git.go
+++ b/pkg/vendir/fetch/git/git.go
@@ -166,49 +166,26 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 		}
 	}
 
-	// Suppress tag fetching when a targeted refspec fetch is possible:
-	//   - named ref (tag/branch): targeted fetch by name
-	//   - locked SHA with a known named original ref: fetch by original ref name
-	// RefSelection needs all tags for semver matching. A bare SHA with no
-	// OriginalRef has no named ref to target and must fall back to a full fetch.
-	canTargetFetch := (len(t.opts.Ref) > 0 && !isHexSHA(t.opts.Ref) && t.opts.RefSelection == nil) ||
-		(isHexSHA(t.opts.Ref) && len(t.opts.OriginalRef) > 0 && !isHexSHA(t.opts.OriginalRef))
-	if canTargetFetch {
-		argss = append(argss, []string{"config", "remote.origin.tagOpt", "--no-tags"})
-	} else {
-		argss = append(argss, []string{"config", "remote.origin.tagOpt", "--tags"})
+	// A targeted refspec fetch (named ref, or locked SHA with a known
+	// OriginalRef) doesn't need all tags. RefSelection needs them for semver
+	// matching, and a bare SHA with no OriginalRef can't be targeted at all.
+	tagOpt := "--tags"
+	if t.canTargetFetch() {
+		tagOpt = noTagsFlag
 	}
+	argss = append(argss, []string{"config", "remote.origin.tagOpt", tagOpt})
 
 	if bundle != "" {
 		argss = append(argss, []string{"bundle", "unbundle", bundle})
 	}
 
 	// When fetching a single named ref, git places it in FETCH_HEAD only —
-	// no local ref is created. Track this so we can use FETCH_HEAD for checkout.
-	var useFetchHead bool
-	{
-		fetchArgs := []string{"fetch", "origin"}
-		switch {
-		case strings.HasPrefix(t.opts.Ref, "origin/"):
-			// only fetch the exact remote branch we're seeking
-			fetchArgs = append(fetchArgs, t.opts.Ref[7:])
-		case len(t.opts.Ref) > 0 && !isHexSHA(t.opts.Ref):
-			// fetch only the named tag or branch; SHAs must use a full fetch
-			fetchArgs = append(fetchArgs, t.opts.Ref, "--no-tags")
-			useFetchHead = true
-		case isHexSHA(t.opts.Ref) && len(t.opts.OriginalRef) > 0 && !isHexSHA(t.opts.OriginalRef):
-			// locked mode: fetch by the original named ref so we avoid a full fetch.
-			// Strip any "origin/" prefix — that prefix is a local tracking convention
-			// and is not a valid remote refspec.
-			originalRef := strings.TrimPrefix(t.opts.OriginalRef, "origin/")
-			fetchArgs = append(fetchArgs, originalRef, "--no-tags")
-			useFetchHead = true
-		}
-		if t.opts.Depth > 0 {
-			fetchArgs = append(fetchArgs, "--depth", strconv.Itoa(t.opts.Depth))
-		}
-		argss = append(argss, fetchArgs)
+	// no local ref is created. Track this to use FETCH_HEAD for checkout.
+	fetchArgs, useFetchHead := t.targetedFetchArgs()
+	if t.opts.Depth > 0 {
+		fetchArgs = append(fetchArgs, "--depth", strconv.Itoa(t.opts.Depth))
 	}
+	argss = append(argss, fetchArgs)
 
 	err = t.cmdRunner.RunMultiple(argss, env, dstPath)
 	if err != nil {
@@ -220,19 +197,22 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 		return err
 	}
 
-	// In locked mode we fetch by the original named ref for performance, but must
-	// check out the exact locked SHA. Verify FETCH_HEAD resolves to that SHA before
-	// checkout so a force-pushed tag is caught early.
+	// In locked mode we fetch by the original named ref for speed, but must
+	// check out the exact locked SHA. Verify FETCH_HEAD resolves to that SHA
+	// before checkout so a force-pushed tag is caught early.
 	if useFetchHead && isHexSHA(t.opts.Ref) {
-		out, _, err := t.cmdRunner.Run([]string{"rev-parse", "FETCH_HEAD^{commit}"}, nil, dstPath)
-		if err != nil {
-			return err
+		rp := []string{"rev-parse", fetchHeadCommit}
+		out, _, runErr := t.cmdRunner.Run(rp, nil, dstPath)
+		if runErr != nil {
+			return runErr
 		}
-		if strings.TrimSpace(out) != t.opts.Ref {
-			return fmt.Errorf("Locked SHA %s does not match fetched commit %s — tag may have been moved", t.opts.Ref, strings.TrimSpace(out))
+		fetchedSHA := strings.TrimSpace(out)
+		if fetchedSHA != t.opts.Ref {
+			return fmt.Errorf("Locked SHA %s does not match fetched "+
+				"commit %s — tag may have been moved", t.opts.Ref, fetchedSHA)
 		}
-		// Use the locked SHA for checkout so mutable refs (e.g. origin/main) don't
-		// cause locked syncs to track the branch tip instead of the pinned commit.
+		// Use the locked SHA for checkout so mutable refs (e.g. origin/main)
+		// don't cause locked syncs to track the branch tip, not the pin.
 		ref = t.opts.Ref
 	} else if useFetchHead {
 		ref = "FETCH_HEAD"
@@ -260,13 +240,58 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 	return nil
 }
 
+const (
+	noTagsFlag      = "--no-tags"
+	fetchHeadCommit = "FETCH_HEAD^{commit}"
+	originPrefix    = "origin/"
+)
+
+// isLockedSHAWithNamedOriginal reports whether Ref is a locked SHA with a
+// known named OriginalRef, i.e. a locked sync that can still target a fetch
+// by name instead of resolving the bare SHA via a full fetch.
+func (t *Git) isLockedSHAWithNamedOriginal() bool {
+	return isHexSHA(t.opts.Ref) &&
+		len(t.opts.OriginalRef) > 0 &&
+		!isHexSHA(t.opts.OriginalRef)
+}
+
+// canTargetFetch reports whether fetch can target a single named ref
+// instead of fetching all branches/tags.
+func (t *Git) canTargetFetch() bool {
+	hasNamedRef := len(t.opts.Ref) > 0 && !isHexSHA(t.opts.Ref)
+	namedRef := hasNamedRef && t.opts.RefSelection == nil
+	return namedRef || t.isLockedSHAWithNamedOriginal()
+}
+
+// targetedFetchArgs builds the "fetch origin ..." args for t.opts.Ref,
+// targeting a single named ref where possible. It reports whether the
+// result lands only in FETCH_HEAD (true) or creates a local ref (false).
+func (t *Git) targetedFetchArgs() ([]string, bool) {
+	fetchArgs := []string{"fetch", "origin"}
+	switch {
+	case strings.HasPrefix(t.opts.Ref, originPrefix):
+		// only fetch the exact remote branch we're seeking
+		branch := strings.TrimPrefix(t.opts.Ref, originPrefix)
+		return append(fetchArgs, branch, noTagsFlag), true
+	case len(t.opts.Ref) > 0 && !isHexSHA(t.opts.Ref):
+		// fetch only the named tag or branch; SHAs must use a full fetch
+		return append(fetchArgs, t.opts.Ref, noTagsFlag), true
+	case t.isLockedSHAWithNamedOriginal():
+		// locked mode: fetch by the original named ref to avoid a full fetch.
+		// origin/ is a local tracking prefix, not a valid remote refspec.
+		originalRef := strings.TrimPrefix(t.opts.OriginalRef, originPrefix)
+		return append(fetchArgs, originalRef, noTagsFlag), true
+	default:
+		// no targeted ref available (e.g. RefSelection, or a bare SHA with
+		// no OriginalRef) — fall back to a full fetch of all branches/tags.
+		return fetchArgs, false
+	}
+}
+
 func (t *Git) resolveRef(dstPath string) (string, error) {
 	switch {
 	case len(t.opts.Ref) > 0:
-		if strings.HasPrefix(t.opts.Ref, "origin/") {
-			return t.opts.Ref[7:], nil
-		}
-		return t.opts.Ref, nil
+		return strings.TrimPrefix(t.opts.Ref, originPrefix), nil
 
 	case t.opts.RefSelection != nil:
 		tags, err := t.tags(dstPath)
@@ -289,19 +314,35 @@ func (t *Git) tags(dstPath string) ([]string, error) {
 	return strings.Split(out, "\n"), nil
 }
 
+const (
+	minAbbreviatedSHALen = 7
+	fullSHALen           = 40
+)
+
 // isHexSHA reports whether s looks like a full or abbreviated git commit SHA
 // (7–40 hex characters, case-insensitive). SHAs cannot be fetched by refspec
 // name and require a full fetch to be resolved.
 func isHexSHA(s string) bool {
-	if len(s) < 7 || len(s) > 40 {
+	if len(s) < minAbbreviatedSHALen || len(s) > fullSHALen {
 		return false
 	}
+	return isHex(s)
+}
+
+func isHex(s string) bool {
 	for _, c := range s {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+		if !isHexDigit(c) {
 			return false
 		}
 	}
 	return true
+}
+
+func isHexDigit(c rune) bool {
+	isDigit := c >= '0' && c <= '9'
+	isLower := c >= 'a' && c <= 'f'
+	isUpper := c >= 'A' && c <= 'F'
+	return isDigit || isLower || isUpper
 }
 
 type CommandRunner interface {

--- a/pkg/vendir/fetch/git/git.go
+++ b/pkg/vendir/fetch/git/git.go
@@ -166,17 +166,40 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 		}
 	}
 
-	argss = append(argss, []string{"config", "remote.origin.tagOpt", "--tags"})
+	// Suppress tag fetching when a targeted refspec fetch is possible:
+	//   - named ref (tag/branch): targeted fetch by name
+	//   - locked SHA with a known named original ref: fetch by original ref name
+	// RefSelection needs all tags for semver matching. A bare SHA with no
+	// OriginalRef has no named ref to target and must fall back to a full fetch.
+	canTargetFetch := (len(t.opts.Ref) > 0 && !isHexSHA(t.opts.Ref) && t.opts.RefSelection == nil) ||
+		(isHexSHA(t.opts.Ref) && len(t.opts.OriginalRef) > 0 && !isHexSHA(t.opts.OriginalRef))
+	if canTargetFetch {
+		argss = append(argss, []string{"config", "remote.origin.tagOpt", "--no-tags"})
+	} else {
+		argss = append(argss, []string{"config", "remote.origin.tagOpt", "--tags"})
+	}
 
 	if bundle != "" {
 		argss = append(argss, []string{"bundle", "unbundle", bundle})
 	}
 
+	// When fetching a single named ref, git places it in FETCH_HEAD only —
+	// no local ref is created. Track this so we can use FETCH_HEAD for checkout.
+	var useFetchHead bool
 	{
 		fetchArgs := []string{"fetch", "origin"}
-		if strings.HasPrefix(t.opts.Ref, "origin/") {
-			// only fetch the exact ref we're seeking
+		switch {
+		case strings.HasPrefix(t.opts.Ref, "origin/"):
+			// only fetch the exact remote branch we're seeking
 			fetchArgs = append(fetchArgs, t.opts.Ref[7:])
+		case len(t.opts.Ref) > 0 && !isHexSHA(t.opts.Ref):
+			// fetch only the named tag or branch; SHAs must use a full fetch
+			fetchArgs = append(fetchArgs, t.opts.Ref, "--no-tags")
+			useFetchHead = true
+		case isHexSHA(t.opts.Ref) && len(t.opts.OriginalRef) > 0 && !isHexSHA(t.opts.OriginalRef):
+			// locked mode: fetch by the original named ref so we avoid a full fetch
+			fetchArgs = append(fetchArgs, t.opts.OriginalRef, "--no-tags")
+			useFetchHead = true
 		}
 		if t.opts.Depth > 0 {
 			fetchArgs = append(fetchArgs, "--depth", strconv.Itoa(t.opts.Depth))
@@ -193,6 +216,9 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 	if err != nil {
 		return err
 	}
+	if useFetchHead {
+		ref = "FETCH_HEAD"
+	}
 
 	if t.opts.Verification != nil {
 		err := Verification{dstPath, *t.opts.Verification, t.refFetcher}.Verify(ref)
@@ -204,6 +230,18 @@ func (t *Git) fetch(dstPath string, tempArea ctlfetch.TempArea, bundle string) e
 	_, _, err = t.cmdRunner.Run([]string{"-c", "advice.detachedHead=false", "checkout", ref}, env, dstPath)
 	if err != nil {
 		return err
+	}
+
+	// In locked mode we fetched by the original named ref; verify the resulting
+	// commit matches the SHA recorded in the lock file.
+	if useFetchHead && isHexSHA(t.opts.Ref) {
+		out, _, err := t.cmdRunner.Run([]string{"rev-parse", "HEAD"}, nil, dstPath)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(out) != t.opts.Ref {
+			return fmt.Errorf("Locked SHA %s does not match fetched commit %s — tag may have been moved", t.opts.Ref, strings.TrimSpace(out))
+		}
 	}
 
 	if !t.opts.SkipInitSubmodules {
@@ -243,6 +281,21 @@ func (t *Git) tags(dstPath string) ([]string, error) {
 	}
 
 	return strings.Split(out, "\n"), nil
+}
+
+// isHexSHA reports whether s looks like a full or abbreviated git commit SHA
+// (7–40 lowercase hex characters). SHAs cannot be fetched by refspec name and
+// require a full fetch to be resolved.
+func isHexSHA(s string) bool {
+	if len(s) < 7 || len(s) > 40 {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
 }
 
 type CommandRunner interface {

--- a/pkg/vendir/fetch/git/git_test.go
+++ b/pkg/vendir/fetch/git/git_test.go
@@ -114,8 +114,8 @@ func TestGit_Retrieve(t *testing.T) {
 		lockedSHA := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
 		runner := &cmdRunnerLocal{
 			commandsToRun: [][]string{},
-			// rev-parse HEAD must return the locked SHA for the post-checkout verification to pass
-			responses: map[string]string{"rev-parse HEAD": lockedSHA},
+			// rev-parse FETCH_HEAD^{commit} must return the locked SHA for verification to pass
+			responses: map[string]string{"rev-parse FETCH_HEAD^{commit}": lockedSHA},
 		}
 		gitRetriever := git.NewGitWithRunner(config.DirectoryContentsGit{
 			URL:         "https://some.git/repo",
@@ -134,13 +134,37 @@ func TestGit_Retrieve(t *testing.T) {
 		require.NotNil(t, tagOptArgs)
 		assert.Equal(t, "--no-tags", tagOptArgs[len(tagOptArgs)-1], "expected --no-tags tagOpt for locked SHA with OriginalRef")
 
+		// Checkout must use the locked SHA directly, not FETCH_HEAD, so mutable
+		// refs (e.g. origin/main) don't cause locked sync to track the branch tip.
 		checkoutArgs := findCheckoutArgs(runner.commandsToRun)
 		require.NotNil(t, checkoutArgs)
-		assert.Contains(t, checkoutArgs, "FETCH_HEAD", "expected FETCH_HEAD checkout in locked SHA mode")
+		assert.Contains(t, checkoutArgs, lockedSHA, "expected locked SHA checkout in locked SHA mode")
+		assert.NotContains(t, checkoutArgs, "FETCH_HEAD", "expected locked SHA, not FETCH_HEAD, for checkout")
 
+		// Verification: rev-parse FETCH_HEAD^{commit} must be called before checkout
 		revParseArgs := findCommandArgs(runner.commandsToRun, "rev-parse")
 		require.NotNil(t, revParseArgs, "expected rev-parse for SHA verification")
-		assert.Contains(t, revParseArgs, "HEAD")
+		assert.Contains(t, revParseArgs, "FETCH_HEAD^{commit}")
+	})
+
+	t.Run("Locked SHA with origin/ OriginalRef strips prefix before fetch", func(t *testing.T) {
+		lockedSHA := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+		runner := &cmdRunnerLocal{
+			commandsToRun: [][]string{},
+			responses:     map[string]string{"rev-parse FETCH_HEAD^{commit}": lockedSHA},
+		}
+		gitRetriever := git.NewGitWithRunner(config.DirectoryContentsGit{
+			URL:         "https://some.git/repo",
+			Ref:         lockedSHA,
+			OriginalRef: "origin/main", // common in vendir configs
+		}, os.Stdout, &fetch.SingleSecretRefFetcher{}, runner)
+		_, err := gitRetriever.Retrieve("", &tmpFolder{t}, "")
+		require.NoError(t, err)
+
+		fetchArgs := findCommandArgs(runner.commandsToRun, "fetch")
+		require.NotNil(t, fetchArgs)
+		assert.Contains(t, fetchArgs, "main", "expected origin/ prefix stripped from OriginalRef")
+		assert.NotContains(t, fetchArgs, "origin/main", "expected origin/ prefix stripped before fetch refspec")
 	})
 
 	t.Run("Plain SHA ref without OriginalRef uses full fetch with --tags", func(t *testing.T) {

--- a/pkg/vendir/fetch/git/git_test.go
+++ b/pkg/vendir/fetch/git/git_test.go
@@ -5,6 +5,7 @@ package git_test
 
 import (
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -90,7 +91,7 @@ func TestGit_Retrieve(t *testing.T) {
 		assert.Contains(t, checkoutArgs, "FETCH_HEAD", "expected FETCH_HEAD checkout for targeted fetch")
 	})
 
-	t.Run("origin/ branch ref uses branch-scoped fetch without --no-tags on refspec", func(t *testing.T) {
+	t.Run("origin/ branch ref uses targeted fetch with --no-tags", func(t *testing.T) {
 		runner := &cmdRunnerLocal{commandsToRun: [][]string{}}
 		gitRetriever := git.NewGitWithRunner(config.DirectoryContentsGit{
 			URL: "https://some.git/repo",
@@ -102,12 +103,11 @@ func TestGit_Retrieve(t *testing.T) {
 		fetchArgs := findCommandArgs(runner.commandsToRun, "fetch")
 		require.NotNil(t, fetchArgs, "expected a fetch command")
 		assert.Contains(t, fetchArgs, "main", "expected branch name in fetch for origin/ ref")
-		assert.NotContains(t, fetchArgs, "--no-tags", "expected no --no-tags on the refspec for origin/ branch")
+		assert.Contains(t, fetchArgs, "--no-tags", "expected --no-tags on the refspec for origin/ branch")
 
 		checkoutArgs := findCheckoutArgs(runner.commandsToRun)
 		require.NotNil(t, checkoutArgs, "expected a checkout command")
-		assert.Contains(t, checkoutArgs, "main", "expected branch name checkout for origin/ ref")
-		assert.NotContains(t, checkoutArgs, "FETCH_HEAD", "expected direct checkout for origin/ ref, not FETCH_HEAD")
+		assert.Contains(t, checkoutArgs, "FETCH_HEAD", "expected FETCH_HEAD checkout for targeted fetch")
 	})
 
 	t.Run("Locked SHA with OriginalRef uses OriginalRef for targeted fetch", func(t *testing.T) {
@@ -225,15 +225,14 @@ func findCheckoutArgs(commands [][]string) []string {
 	return nil
 }
 
+// minConfigArgs is "config" plus at least the key being configured.
+const minConfigArgs = 2
+
 // findConfigArgs finds the git config command that sets the given key.
 func findConfigArgs(commands [][]string, key string) []string {
 	for _, args := range commands {
-		if len(args) >= 2 && args[0] == "config" {
-			for _, a := range args[1:] {
-				if a == key {
-					return args
-				}
-			}
+		if len(args) >= minConfigArgs && args[0] == "config" && slices.Contains(args[1:], key) {
+			return args
 		}
 	}
 	return nil

--- a/pkg/vendir/fetch/git/git_test.go
+++ b/pkg/vendir/fetch/git/git_test.go
@@ -11,6 +11,7 @@ import (
 	"carvel.dev/vendir/pkg/vendir/config"
 	"carvel.dev/vendir/pkg/vendir/fetch"
 	"carvel.dev/vendir/pkg/vendir/fetch/git"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,10 +66,159 @@ func TestGit_Retrieve(t *testing.T) {
 		_, err := gitRetriever.Retrieve("", &tmpFolder{t}, "")
 		require.ErrorContains(t, err, "Username/password authentication is only supported for https remotes")
 	})
+
+	t.Run("Named tag ref uses targeted fetch with --no-tags", func(t *testing.T) {
+		runner := &cmdRunnerLocal{commandsToRun: [][]string{}}
+		gitRetriever := git.NewGitWithRunner(config.DirectoryContentsGit{
+			URL: "https://some.git/repo",
+			Ref: "v1.2.3",
+		}, os.Stdout, &fetch.SingleSecretRefFetcher{}, runner)
+		_, err := gitRetriever.Retrieve("", &tmpFolder{t}, "")
+		require.NoError(t, err)
+
+		fetchArgs := findCommandArgs(runner.commandsToRun, "fetch")
+		require.NotNil(t, fetchArgs, "expected a fetch command")
+		assert.Contains(t, fetchArgs, "v1.2.3", "expected specific ref in fetch")
+		assert.Contains(t, fetchArgs, "--no-tags", "expected --no-tags for named ref fetch")
+
+		tagOptArgs := findConfigArgs(runner.commandsToRun, "remote.origin.tagOpt")
+		require.NotNil(t, tagOptArgs, "expected tagOpt config command")
+		assert.Equal(t, "--no-tags", tagOptArgs[len(tagOptArgs)-1], "expected --no-tags tagOpt for named ref")
+
+		checkoutArgs := findCheckoutArgs(runner.commandsToRun)
+		require.NotNil(t, checkoutArgs, "expected a checkout command")
+		assert.Contains(t, checkoutArgs, "FETCH_HEAD", "expected FETCH_HEAD checkout for targeted fetch")
+	})
+
+	t.Run("origin/ branch ref uses branch-scoped fetch without --no-tags on refspec", func(t *testing.T) {
+		runner := &cmdRunnerLocal{commandsToRun: [][]string{}}
+		gitRetriever := git.NewGitWithRunner(config.DirectoryContentsGit{
+			URL: "https://some.git/repo",
+			Ref: "origin/main",
+		}, os.Stdout, &fetch.SingleSecretRefFetcher{}, runner)
+		_, err := gitRetriever.Retrieve("", &tmpFolder{t}, "")
+		require.NoError(t, err)
+
+		fetchArgs := findCommandArgs(runner.commandsToRun, "fetch")
+		require.NotNil(t, fetchArgs, "expected a fetch command")
+		assert.Contains(t, fetchArgs, "main", "expected branch name in fetch for origin/ ref")
+		assert.NotContains(t, fetchArgs, "--no-tags", "expected no --no-tags on the refspec for origin/ branch")
+
+		checkoutArgs := findCheckoutArgs(runner.commandsToRun)
+		require.NotNil(t, checkoutArgs, "expected a checkout command")
+		assert.Contains(t, checkoutArgs, "main", "expected branch name checkout for origin/ ref")
+		assert.NotContains(t, checkoutArgs, "FETCH_HEAD", "expected direct checkout for origin/ ref, not FETCH_HEAD")
+	})
+
+	t.Run("Locked SHA with OriginalRef uses OriginalRef for targeted fetch", func(t *testing.T) {
+		lockedSHA := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+		runner := &cmdRunnerLocal{
+			commandsToRun: [][]string{},
+			// rev-parse HEAD must return the locked SHA for the post-checkout verification to pass
+			responses: map[string]string{"rev-parse HEAD": lockedSHA},
+		}
+		gitRetriever := git.NewGitWithRunner(config.DirectoryContentsGit{
+			URL:         "https://some.git/repo",
+			Ref:         lockedSHA,
+			OriginalRef: "v1.2.3",
+		}, os.Stdout, &fetch.SingleSecretRefFetcher{}, runner)
+		_, err := gitRetriever.Retrieve("", &tmpFolder{t}, "")
+		require.NoError(t, err)
+
+		fetchArgs := findCommandArgs(runner.commandsToRun, "fetch")
+		require.NotNil(t, fetchArgs, "expected a fetch command")
+		assert.Contains(t, fetchArgs, "v1.2.3", "expected OriginalRef in fetch for locked SHA mode")
+		assert.Contains(t, fetchArgs, "--no-tags", "expected --no-tags for locked SHA with OriginalRef")
+
+		tagOptArgs := findConfigArgs(runner.commandsToRun, "remote.origin.tagOpt")
+		require.NotNil(t, tagOptArgs)
+		assert.Equal(t, "--no-tags", tagOptArgs[len(tagOptArgs)-1], "expected --no-tags tagOpt for locked SHA with OriginalRef")
+
+		checkoutArgs := findCheckoutArgs(runner.commandsToRun)
+		require.NotNil(t, checkoutArgs)
+		assert.Contains(t, checkoutArgs, "FETCH_HEAD", "expected FETCH_HEAD checkout in locked SHA mode")
+
+		revParseArgs := findCommandArgs(runner.commandsToRun, "rev-parse")
+		require.NotNil(t, revParseArgs, "expected rev-parse for SHA verification")
+		assert.Contains(t, revParseArgs, "HEAD")
+	})
+
+	t.Run("Plain SHA ref without OriginalRef uses full fetch with --tags", func(t *testing.T) {
+		runner := &cmdRunnerLocal{commandsToRun: [][]string{}}
+		gitRetriever := git.NewGitWithRunner(config.DirectoryContentsGit{
+			URL: "https://some.git/repo",
+			Ref: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", // 40-char hex SHA, no OriginalRef
+		}, os.Stdout, &fetch.SingleSecretRefFetcher{}, runner)
+		_, err := gitRetriever.Retrieve("", &tmpFolder{t}, "")
+		require.NoError(t, err)
+
+		fetchArgs := findCommandArgs(runner.commandsToRun, "fetch")
+		require.NotNil(t, fetchArgs, "expected a fetch command")
+		// full fetch: only "fetch" and "origin", no extra refspec
+		assert.Equal(t, []string{"fetch", "origin"}, fetchArgs, "expected bare full fetch for plain SHA")
+
+		tagOptArgs := findConfigArgs(runner.commandsToRun, "remote.origin.tagOpt")
+		require.NotNil(t, tagOptArgs)
+		assert.Equal(t, "--tags", tagOptArgs[len(tagOptArgs)-1], "expected --tags tagOpt for plain SHA ref")
+	})
+
+	t.Run("Depth flag is appended after refspec for named ref targeted fetch", func(t *testing.T) {
+		runner := &cmdRunnerLocal{commandsToRun: [][]string{}}
+		gitRetriever := git.NewGitWithRunner(config.DirectoryContentsGit{
+			URL:   "https://some.git/repo",
+			Ref:   "v1.2.3",
+			Depth: 1,
+		}, os.Stdout, &fetch.SingleSecretRefFetcher{}, runner)
+		_, err := gitRetriever.Retrieve("", &tmpFolder{t}, "")
+		require.NoError(t, err)
+
+		fetchArgs := findCommandArgs(runner.commandsToRun, "fetch")
+		require.NotNil(t, fetchArgs)
+		fetchStr := strings.Join(fetchArgs, " ")
+		assert.Contains(t, fetchStr, "v1.2.3 --no-tags --depth 1", "expected refspec, --no-tags, then --depth in order")
+	})
+}
+
+// findCommandArgs finds the first command in commandsToRun whose first arg matches firstArg.
+func findCommandArgs(commands [][]string, firstArg string) []string {
+	for _, args := range commands {
+		if len(args) > 0 && args[0] == firstArg {
+			return args
+		}
+	}
+	return nil
+}
+
+// findCheckoutArgs finds the git checkout command (issued as "-c advice.detachedHead=false checkout ...").
+func findCheckoutArgs(commands [][]string) []string {
+	for _, args := range commands {
+		for i, a := range args {
+			if a == "checkout" {
+				return args[i:]
+			}
+		}
+	}
+	return nil
+}
+
+// findConfigArgs finds the git config command that sets the given key.
+func findConfigArgs(commands [][]string, key string) []string {
+	for _, args := range commands {
+		if len(args) >= 2 && args[0] == "config" {
+			for _, a := range args[1:] {
+				if a == key {
+					return args
+				}
+			}
+		}
+	}
+	return nil
 }
 
 type cmdRunnerLocal struct {
 	commandsToRun [][]string
+	// responses maps "arg0 arg1 ..." to the stdout value Run should return.
+	responses map[string]string
 }
 
 func (c *cmdRunnerLocal) RunMultiple(argss [][]string, _ []string, _ string) error {
@@ -78,6 +228,11 @@ func (c *cmdRunnerLocal) RunMultiple(argss [][]string, _ []string, _ string) err
 
 func (c *cmdRunnerLocal) Run(args []string, _ []string, _ string) (string, string, error) {
 	c.commandsToRun = append(c.commandsToRun, args)
+	if c.responses != nil {
+		if out, ok := c.responses[strings.Join(args, " ")]; ok {
+			return out, "", nil
+		}
+	}
 	return "", "", nil
 }
 

--- a/pkg/vendir/fetch/http/sync.go
+++ b/pkg/vendir/fetch/http/sync.go
@@ -195,8 +195,7 @@ func (t *Sync) addAuth(req *http.Request) error {
 
 	// Basic auth — password is optional, defaults to empty string
 	if hasUser {
-		password := string(secret.Data[
-			ctlconf.SecretK8sCorev1BasicAuthPasswordKey])
+		password := string(secret.Data[ctlconf.SecretK8sCorev1BasicAuthPasswordKey])
 		req.SetBasicAuth(
 			string(secret.Data[ctlconf.SecretK8sCorev1BasicAuthUsernameKey]),
 			password,

--- a/pkg/vendir/fetch/http/sync.go
+++ b/pkg/vendir/fetch/http/sync.go
@@ -195,7 +195,8 @@ func (t *Sync) addAuth(req *http.Request) error {
 
 	// Basic auth — password is optional, defaults to empty string
 	if hasUser {
-		password := string(secret.Data[ctlconf.SecretK8sCorev1BasicAuthPasswordKey])
+		passwordKey := ctlconf.SecretK8sCorev1BasicAuthPasswordKey
+		password := string(secret.Data[passwordKey])
 		req.SetBasicAuth(
 			string(secret.Data[ctlconf.SecretK8sCorev1BasicAuthUsernameKey]),
 			password,

--- a/test/e2e/git_test.go
+++ b/test/e2e/git_test.go
@@ -283,14 +283,18 @@ directories:
 		var vendirOutput VendirOutput
 		require.NoError(t, json.NewDecoder(&stdout).Decode(&vendirOutput))
 
-		var foundTargetedFetch bool
+		var foundTargetedFetch, foundBareFetch bool
 		for _, l := range vendirOutput.Lines {
 			if strings.Contains(l, "fetch origin signed-trusted-tag --no-tags") {
 				foundTargetedFetch = true
 			}
-			assert.NotContains(t, l, "--> git fetch origin\n", "expected no bare full fetch for named tag ref")
+			// "--> git fetch origin" followed by a depth/no refspec is the old slow path
+			if strings.Contains(l, "--> git fetch origin") && !strings.Contains(l, "signed-trusted-tag") {
+				foundBareFetch = true
+			}
 		}
 		assert.True(t, foundTargetedFetch, "expected targeted fetch line 'fetch origin signed-trusted-tag --no-tags'")
+		assert.False(t, foundBareFetch, "expected no bare full fetch for named tag ref")
 
 		_, err = os.Stat(filepath.Join(dstPath, "vendor", "test"))
 		assert.NoError(t, err, "expected vendored directory to exist after sync")

--- a/test/e2e/git_test.go
+++ b/test/e2e/git_test.go
@@ -235,6 +235,131 @@ directories:
 	require.True(t, unbundled, "git did not use the cached bundle")
 }
 
+func TestGitFetchOptimizations(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	vendir := Vendir{t, env.BinaryPath, logger}
+
+	gitSrcPath, err := os.MkdirTemp("", "vendir-e2e-git-fetch-opt")
+	require.NoError(t, err)
+	defer os.RemoveAll(gitSrcPath)
+
+	out, err := exec.Command("tar", "xzvf", "assets/git-repo-signed/asset.tgz", "-C", gitSrcPath).CombinedOutput()
+	require.NoErrorf(t, err, "Unpacking git-repo-signed asset (output: '%s')", out)
+
+	repoPath := filepath.Join(gitSrcPath, "git-repo")
+
+	// SHAs are stable — baked into the tarball.
+	const (
+		signedTrustedTagSHA = "35a63c8ba40a44f6bdf16c6ea8ae589d8539cc5b"
+		masterHeadSHA       = "f0076929d229f0819eabd2d1937bdb6aa148f19f"
+	)
+
+	yamlConfig := func(ref string) string {
+		return fmt.Sprintf(`
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+- path: vendor
+  contents:
+  - path: test
+    git:
+      url: "%s"
+      ref: "%s"
+`, repoPath, ref)
+	}
+
+	logger.Section("named tag fetch uses targeted FETCH_HEAD path", func() {
+		dstPath, err := os.MkdirTemp("", "vendir-e2e-git-fetch-opt-dst")
+		require.NoError(t, err)
+		defer os.RemoveAll(dstPath)
+
+		var stdout bytes.Buffer
+		vendir.RunWithOpts(
+			[]string{"sync", "-f", "-", "--json"},
+			RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig("signed-trusted-tag")), StdoutWriter: &stdout},
+		)
+
+		var vendirOutput VendirOutput
+		require.NoError(t, json.NewDecoder(&stdout).Decode(&vendirOutput))
+
+		var foundTargetedFetch bool
+		for _, l := range vendirOutput.Lines {
+			if strings.Contains(l, "fetch origin signed-trusted-tag --no-tags") {
+				foundTargetedFetch = true
+			}
+			assert.NotContains(t, l, "--> git fetch origin\n", "expected no bare full fetch for named tag ref")
+		}
+		assert.True(t, foundTargetedFetch, "expected targeted fetch line 'fetch origin signed-trusted-tag --no-tags'")
+
+		_, err = os.Stat(filepath.Join(dstPath, "vendor", "test"))
+		assert.NoError(t, err, "expected vendored directory to exist after sync")
+	})
+
+	logger.Section("locked sync uses OriginalRef for targeted fetch (not bare SHA fetch)", func() {
+		dstPath, err := os.MkdirTemp("", "vendir-e2e-git-fetch-opt-locked-dst")
+		require.NoError(t, err)
+		defer os.RemoveAll(dstPath)
+
+		// First sync to produce a lock file
+		vendir.RunWithOpts(
+			[]string{"sync", "-f", "-"},
+			RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig("signed-trusted-tag"))},
+		)
+
+		// Locked sync: should use OriginalRef ("signed-trusted-tag") not the SHA
+		var stdout bytes.Buffer
+		vendir.RunWithOpts(
+			[]string{"sync", "--locked", "-f", "-", "--json"},
+			RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig("signed-trusted-tag")), StdoutWriter: &stdout},
+		)
+
+		var vendirOutput VendirOutput
+		require.NoError(t, json.NewDecoder(&stdout).Decode(&vendirOutput))
+
+		var foundTargetedFetch bool
+		for _, l := range vendirOutput.Lines {
+			if strings.Contains(l, "fetch origin signed-trusted-tag --no-tags") {
+				foundTargetedFetch = true
+			}
+		}
+		assert.True(t, foundTargetedFetch, "expected locked sync to use OriginalRef for targeted fetch")
+	})
+
+	logger.Section("locked sync detects tampered lock SHA", func() {
+		dstPath, err := os.MkdirTemp("", "vendir-e2e-git-fetch-opt-tampered-dst")
+		require.NoError(t, err)
+		defer os.RemoveAll(dstPath)
+
+		// Write a vendir.yml pointing at the tag
+		err = os.WriteFile(filepath.Join(dstPath, "vendir.yml"), []byte(yamlConfig("signed-trusted-tag")), 0600)
+		require.NoError(t, err)
+
+		// Write a lock file with a different (valid) SHA — masterHeadSHA ≠ signedTrustedTagSHA
+		lockContent := fmt.Sprintf(`apiVersion: vendir.k14s.io/v1alpha1
+kind: LockConfig
+directories:
+- path: vendor
+  contents:
+  - path: test
+    git:
+      sha: "%s"
+      commitTitle: tampered
+`, masterHeadSHA)
+		err = os.WriteFile(filepath.Join(dstPath, "vendir.lock.yml"), []byte(lockContent), 0600)
+		require.NoError(t, err)
+
+		_, err = vendir.RunWithOpts(
+			[]string{"sync", "--locked"},
+			RunOpts{Dir: dstPath, AllowError: true},
+		)
+		require.Error(t, err, "expected error when lock SHA does not match fetched commit")
+		assert.Contains(t, err.Error(), "Locked SHA", "expected error to mention locked SHA")
+		assert.Contains(t, err.Error(), "does not match fetched commit", "expected error to describe the mismatch")
+		_ = signedTrustedTagSHA // used in comment above for clarity
+	})
+}
+
 func readFile(t *testing.T, path string) string {
 	contents, err := os.ReadFile(path)
 	if err != nil {

--- a/test/e2e/git_test.go
+++ b/test/e2e/git_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const gitRepoAssetDir = "git-repo"
+
 func TestGitVerification(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
@@ -45,7 +47,7 @@ func TestGitVerification(t *testing.T) {
 
 	yamlConfigWithPubKeys := func(ref string, pubKeys string) io.Reader {
 		encodedPubKeys := base64.StdEncoding.EncodeToString([]byte(pubKeys))
-		repoPath := filepath.Join(gitSrcPath, "git-repo")
+		repoPath := filepath.Join(gitSrcPath, gitRepoAssetDir)
 		return strings.NewReader(fmt.Sprintf(`
 apiVersion: v1
 kind: Secret
@@ -160,7 +162,7 @@ func TestGitCache(t *testing.T) {
 
 	yamlConfigWithPubKeys := func(ref string, pubKeys string) io.Reader {
 		encodedPubKeys := base64.StdEncoding.EncodeToString([]byte(pubKeys))
-		repoPath := filepath.Join(gitSrcPath, "git-repo")
+		repoPath := filepath.Join(gitSrcPath, gitRepoAssetDir)
 		return strings.NewReader(fmt.Sprintf(`
 apiVersion: v1
 kind: Secret
@@ -235,25 +237,27 @@ directories:
 	require.True(t, unbundled, "git did not use the cached bundle")
 }
 
-func TestGitFetchOptimizations(t *testing.T) {
+// masterHeadSHA is stable — baked into the git-repo-signed test asset tarball.
+const masterHeadSHA = "f0076929d229f0819eabd2d1937bdb6aa148f19f"
+
+const ownerReadWrite = 0600
+
+// gitFetchOptTestSetup unpacks the shared test git repo and returns a vendir
+// runner plus a yamlConfig builder pointing at it.
+func gitFetchOptTestSetup(t *testing.T) (Vendir, func(ref string) string) {
 	env := BuildEnv(t)
-	logger := Logger{}
-	vendir := Vendir{t, env.BinaryPath, logger}
+	vendir := Vendir{t, env.BinaryPath, Logger{}}
 
 	gitSrcPath, err := os.MkdirTemp("", "vendir-e2e-git-fetch-opt")
 	require.NoError(t, err)
-	defer os.RemoveAll(gitSrcPath)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(gitSrcPath))
+	})
 
 	out, err := exec.Command("tar", "xzvf", "assets/git-repo-signed/asset.tgz", "-C", gitSrcPath).CombinedOutput()
 	require.NoErrorf(t, err, "Unpacking git-repo-signed asset (output: '%s')", out)
 
-	repoPath := filepath.Join(gitSrcPath, "git-repo")
-
-	// SHAs are stable — baked into the tarball.
-	const (
-		signedTrustedTagSHA = "35a63c8ba40a44f6bdf16c6ea8ae589d8539cc5b"
-		masterHeadSHA       = "f0076929d229f0819eabd2d1937bdb6aa148f19f"
-	)
+	repoPath := filepath.Join(gitSrcPath, gitRepoAssetDir)
 
 	yamlConfig := func(ref string) string {
 		return fmt.Sprintf(`
@@ -269,78 +273,90 @@ directories:
 `, repoPath, ref)
 	}
 
-	logger.Section("named tag fetch uses targeted FETCH_HEAD path", func() {
-		dstPath, err := os.MkdirTemp("", "vendir-e2e-git-fetch-opt-dst")
-		require.NoError(t, err)
-		defer os.RemoveAll(dstPath)
+	return vendir, yamlConfig
+}
 
-		var stdout bytes.Buffer
-		vendir.RunWithOpts(
-			[]string{"sync", "-f", "-", "--json"},
-			RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig("signed-trusted-tag")), StdoutWriter: &stdout},
-		)
+func TestGitFetchOptimizationsNamedTag(t *testing.T) {
+	vendir, yamlConfig := gitFetchOptTestSetup(t)
 
-		var vendirOutput VendirOutput
-		require.NoError(t, json.NewDecoder(&stdout).Decode(&vendirOutput))
+	dstPath, err := os.MkdirTemp("", "vendir-e2e-git-fetch-opt-dst")
+	require.NoError(t, err)
+	defer os.RemoveAll(dstPath)
 
-		var foundTargetedFetch, foundBareFetch bool
-		for _, l := range vendirOutput.Lines {
-			if strings.Contains(l, "fetch origin signed-trusted-tag --no-tags") {
-				foundTargetedFetch = true
-			}
-			// "--> git fetch origin" followed by a depth/no refspec is the old slow path
-			if strings.Contains(l, "--> git fetch origin") && !strings.Contains(l, "signed-trusted-tag") {
-				foundBareFetch = true
-			}
+	var stdout bytes.Buffer
+	_, err = vendir.RunWithOpts(
+		[]string{"sync", "-f", "-", "--json"},
+		RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig("signed-trusted-tag")), StdoutWriter: &stdout},
+	)
+	require.NoError(t, err)
+
+	var vendirOutput VendirOutput
+	require.NoError(t, json.NewDecoder(&stdout).Decode(&vendirOutput))
+
+	var foundTargetedFetch, foundBareFetch bool
+	for _, l := range vendirOutput.Lines {
+		if strings.Contains(l, "fetch origin signed-trusted-tag --no-tags") {
+			foundTargetedFetch = true
 		}
-		assert.True(t, foundTargetedFetch, "expected targeted fetch line 'fetch origin signed-trusted-tag --no-tags'")
-		assert.False(t, foundBareFetch, "expected no bare full fetch for named tag ref")
-
-		_, err = os.Stat(filepath.Join(dstPath, "vendor", "test"))
-		assert.NoError(t, err, "expected vendored directory to exist after sync")
-	})
-
-	logger.Section("locked sync uses OriginalRef for targeted fetch (not bare SHA fetch)", func() {
-		dstPath, err := os.MkdirTemp("", "vendir-e2e-git-fetch-opt-locked-dst")
-		require.NoError(t, err)
-		defer os.RemoveAll(dstPath)
-
-		// First sync to produce a lock file
-		vendir.RunWithOpts(
-			[]string{"sync", "-f", "-"},
-			RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig("signed-trusted-tag"))},
-		)
-
-		// Locked sync: should use OriginalRef ("signed-trusted-tag") not the SHA
-		var stdout bytes.Buffer
-		vendir.RunWithOpts(
-			[]string{"sync", "--locked", "-f", "-", "--json"},
-			RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig("signed-trusted-tag")), StdoutWriter: &stdout},
-		)
-
-		var vendirOutput VendirOutput
-		require.NoError(t, json.NewDecoder(&stdout).Decode(&vendirOutput))
-
-		var foundTargetedFetch bool
-		for _, l := range vendirOutput.Lines {
-			if strings.Contains(l, "fetch origin signed-trusted-tag --no-tags") {
-				foundTargetedFetch = true
-			}
+		// "--> git fetch origin" followed by a depth/no refspec is the old slow path
+		if strings.Contains(l, "--> git fetch origin") && !strings.Contains(l, "signed-trusted-tag") {
+			foundBareFetch = true
 		}
-		assert.True(t, foundTargetedFetch, "expected locked sync to use OriginalRef for targeted fetch")
-	})
+	}
+	assert.True(t, foundTargetedFetch, "expected targeted fetch line 'fetch origin signed-trusted-tag --no-tags'")
+	assert.False(t, foundBareFetch, "expected no bare full fetch for named tag ref")
 
-	logger.Section("locked sync detects tampered lock SHA", func() {
-		dstPath, err := os.MkdirTemp("", "vendir-e2e-git-fetch-opt-tampered-dst")
-		require.NoError(t, err)
-		defer os.RemoveAll(dstPath)
+	_, err = os.Stat(filepath.Join(dstPath, "vendor", "test"))
+	assert.NoError(t, err, "expected vendored directory to exist after sync")
+}
 
-		// Write a vendir.yml pointing at the tag
-		err = os.WriteFile(filepath.Join(dstPath, "vendir.yml"), []byte(yamlConfig("signed-trusted-tag")), 0600)
-		require.NoError(t, err)
+func TestGitFetchOptimizationsLockedSync(t *testing.T) {
+	vendir, yamlConfig := gitFetchOptTestSetup(t)
 
-		// Write a lock file with a different (valid) SHA — masterHeadSHA ≠ signedTrustedTagSHA
-		lockContent := fmt.Sprintf(`apiVersion: vendir.k14s.io/v1alpha1
+	dstPath, err := os.MkdirTemp("", "vendir-e2e-git-fetch-opt-locked-dst")
+	require.NoError(t, err)
+	defer os.RemoveAll(dstPath)
+
+	// First sync to produce a lock file
+	_, err = vendir.RunWithOpts(
+		[]string{"sync", "-f", "-"},
+		RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig("signed-trusted-tag"))},
+	)
+	require.NoError(t, err)
+
+	// Locked sync: should use OriginalRef ("signed-trusted-tag") not the SHA
+	var stdout bytes.Buffer
+	_, err = vendir.RunWithOpts(
+		[]string{"sync", "--locked", "-f", "-", "--json"},
+		RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig("signed-trusted-tag")), StdoutWriter: &stdout},
+	)
+	require.NoError(t, err)
+
+	var vendirOutput VendirOutput
+	require.NoError(t, json.NewDecoder(&stdout).Decode(&vendirOutput))
+
+	var foundTargetedFetch bool
+	for _, l := range vendirOutput.Lines {
+		if strings.Contains(l, "fetch origin signed-trusted-tag --no-tags") {
+			foundTargetedFetch = true
+		}
+	}
+	assert.True(t, foundTargetedFetch, "expected locked sync to use OriginalRef for targeted fetch")
+}
+
+func TestGitFetchOptimizationsTamperedLockSHA(t *testing.T) {
+	vendir, yamlConfig := gitFetchOptTestSetup(t)
+
+	dstPath, err := os.MkdirTemp("", "vendir-e2e-git-fetch-opt-tampered-dst")
+	require.NoError(t, err)
+	defer os.RemoveAll(dstPath)
+
+	// Write a vendir.yml pointing at the tag
+	err = os.WriteFile(filepath.Join(dstPath, "vendir.yml"), []byte(yamlConfig("signed-trusted-tag")), ownerReadWrite)
+	require.NoError(t, err)
+
+	// Write a lock file with a different (valid) SHA — masterHeadSHA ≠ the tag's SHA
+	lockContent := fmt.Sprintf(`apiVersion: vendir.k14s.io/v1alpha1
 kind: LockConfig
 directories:
 - path: vendor
@@ -350,18 +366,16 @@ directories:
       sha: "%s"
       commitTitle: tampered
 `, masterHeadSHA)
-		err = os.WriteFile(filepath.Join(dstPath, "vendir.lock.yml"), []byte(lockContent), 0600)
-		require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dstPath, "vendir.lock.yml"), []byte(lockContent), ownerReadWrite)
+	require.NoError(t, err)
 
-		_, err = vendir.RunWithOpts(
-			[]string{"sync", "--locked"},
-			RunOpts{Dir: dstPath, AllowError: true},
-		)
-		require.Error(t, err, "expected error when lock SHA does not match fetched commit")
-		assert.Contains(t, err.Error(), "Locked SHA", "expected error to mention locked SHA")
-		assert.Contains(t, err.Error(), "does not match fetched commit", "expected error to describe the mismatch")
-		_ = signedTrustedTagSHA // used in comment above for clarity
-	})
+	_, err = vendir.RunWithOpts(
+		[]string{"sync", "--locked"},
+		RunOpts{Dir: dstPath, AllowError: true},
+	)
+	require.Error(t, err, "expected error when lock SHA does not match fetched commit")
+	assert.Contains(t, err.Error(), "Locked SHA", "expected error to mention locked SHA")
+	assert.Contains(t, err.Error(), "does not match fetched commit", "expected error to describe the mismatch")
 }
 
 func readFile(t *testing.T, path string) string {

--- a/test/e2e/git_test.go
+++ b/test/e2e/git_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 const gitRepoAssetDir = "git-repo"
+const signedTrustedTag = "signed-trusted-tag"
 
 func TestGitVerification(t *testing.T) {
 	env := BuildEnv(t)
@@ -89,7 +90,7 @@ directories:
 	})
 
 	logger.Section("signed trusted tag", func() {
-		ref := "signed-trusted-tag"
+		ref := signedTrustedTag
 		vendir.RunWithOpts([]string{"sync", "-f", "-"}, RunOpts{Dir: dstPath, StdinReader: yamlConfig(ref)})
 	})
 
@@ -197,7 +198,7 @@ directories:
 		[]string{"sync", "-f", "-", "--json"},
 		RunOpts{
 			Dir:          dstPath,
-			StdinReader:  yamlConfig("signed-trusted-tag"),
+			StdinReader:  yamlConfig(signedTrustedTag),
 			StdoutWriter: &stdout,
 			Env: []string{
 				"VENDIR_CACHE_DIR=" + tmpDir,
@@ -218,7 +219,7 @@ directories:
 		[]string{"sync", "-f", "-", "--json"},
 		RunOpts{
 			Dir:          dstPath,
-			StdinReader:  yamlConfig("signed-trusted-tag"),
+			StdinReader:  yamlConfig(signedTrustedTag),
 			StdoutWriter: &stdout,
 			Env: []string{
 				"VENDIR_CACHE_DIR=" + tmpDir,
@@ -286,7 +287,7 @@ func TestGitFetchOptimizationsNamedTag(t *testing.T) {
 	var stdout bytes.Buffer
 	_, err = vendir.RunWithOpts(
 		[]string{"sync", "-f", "-", "--json"},
-		RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig("signed-trusted-tag")), StdoutWriter: &stdout},
+		RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig(signedTrustedTag)), StdoutWriter: &stdout},
 	)
 	require.NoError(t, err)
 
@@ -295,11 +296,14 @@ func TestGitFetchOptimizationsNamedTag(t *testing.T) {
 
 	var foundTargetedFetch, foundBareFetch bool
 	for _, l := range vendirOutput.Lines {
-		if strings.Contains(l, "fetch origin signed-trusted-tag --no-tags") {
+		if strings.Contains(l, "fetch origin") &&
+			strings.Contains(l, signedTrustedTag) &&
+			strings.Contains(l, "--no-tags") {
 			foundTargetedFetch = true
 		}
 		// "--> git fetch origin" followed by a depth/no refspec is the old slow path
-		if strings.Contains(l, "--> git fetch origin") && !strings.Contains(l, "signed-trusted-tag") {
+		if strings.Contains(l, "--> git fetch origin") &&
+			!strings.Contains(l, signedTrustedTag) {
 			foundBareFetch = true
 		}
 	}
@@ -320,7 +324,7 @@ func TestGitFetchOptimizationsLockedSync(t *testing.T) {
 	// First sync to produce a lock file
 	_, err = vendir.RunWithOpts(
 		[]string{"sync", "-f", "-"},
-		RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig("signed-trusted-tag"))},
+		RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig(signedTrustedTag))},
 	)
 	require.NoError(t, err)
 
@@ -328,7 +332,7 @@ func TestGitFetchOptimizationsLockedSync(t *testing.T) {
 	var stdout bytes.Buffer
 	_, err = vendir.RunWithOpts(
 		[]string{"sync", "--locked", "-f", "-", "--json"},
-		RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig("signed-trusted-tag")), StdoutWriter: &stdout},
+		RunOpts{Dir: dstPath, StdinReader: strings.NewReader(yamlConfig(signedTrustedTag)), StdoutWriter: &stdout},
 	)
 	require.NoError(t, err)
 
@@ -337,7 +341,9 @@ func TestGitFetchOptimizationsLockedSync(t *testing.T) {
 
 	var foundTargetedFetch bool
 	for _, l := range vendirOutput.Lines {
-		if strings.Contains(l, "fetch origin signed-trusted-tag --no-tags") {
+		if strings.Contains(l, "fetch origin") &&
+			strings.Contains(l, signedTrustedTag) &&
+			strings.Contains(l, "--no-tags") {
 			foundTargetedFetch = true
 		}
 	}
@@ -352,7 +358,7 @@ func TestGitFetchOptimizationsTamperedLockSHA(t *testing.T) {
 	defer os.RemoveAll(dstPath)
 
 	// Write a vendir.yml pointing at the tag
-	err = os.WriteFile(filepath.Join(dstPath, "vendir.yml"), []byte(yamlConfig("signed-trusted-tag")), ownerReadWrite)
+	err = os.WriteFile(filepath.Join(dstPath, "vendir.yml"), []byte(yamlConfig(signedTrustedTag)), ownerReadWrite)
 	require.NoError(t, err)
 
 	// Write a lock file with a different (valid) SHA — masterHeadSHA ≠ the tag's SHA


### PR DESCRIPTION
## Problem

`vendir sync` is very slow for git repositories with large numbers of branches and tags. The root cause is that the git fetcher unconditionally:
1. Set `remote.origin.tagOpt = --tags`, causing all tag objects to be downloaded on every fetch
2. Did not pass a refspec to `git fetch`, causing all remote refs to be negotiated

On a repo with thousands of branches and tags, this turns every sync into a multi-megabyte download regardless of what ref you actually need.

## Solution

When a fixed named ref is specified (tag or branch, not a SHA), use a targeted single-refspec fetch:

```
git fetch origin <ref> --no-tags [--depth N]
```

Then check out `FETCH_HEAD` (which git populates from a single-refspec fetch) instead of the ref name.

`--tags` is kept only where it's actually needed:
- `refSelection` (semver matching must enumerate all tags)
- Plain SHA refs with no `OriginalRef` (SHAs can't be fetched by name)

### `--locked` path

`--locked` substitutes the locked SHA for the original ref before reaching the fetcher, which previously forced a full `--tags` fetch every time. This PR preserves the original ref in a new unexported `OriginalRef` field on `DirectoryContentsGit` (set by `Lock()`, not serialized to YAML). The fetcher uses it for the same targeted fetch path, then verifies the resulting commit SHA matches the lock — catching force-pushed tags.

## Performance

Measured against an internal repo with thousands of branches and hundreds of tags:

| Command | Before | After | Improvement |
|---|---|---|---|
| `vendir sync` | 43s | 11s | **74% faster** |
| `vendir sync --locked` | 1m 26s | 9s | **89% faster** |

## Changes

- `pkg/vendir/config/directory.go` — add `OriginalRef string` (unexported from YAML) to `DirectoryContentsGit`; set it in `Lock()` before overwriting `Ref` with the SHA
- `pkg/vendir/fetch/git/git.go` — targeted refspec fetch for named refs and locked-SHA-with-OriginalRef; conditional `--tags`/`--no-tags`; post-checkout SHA verification in locked mode; `isHexSHA()` helper
- `pkg/vendir/fetch/git/git_test.go` — unit tests for each fetch path (named tag, `origin/` branch, locked SHA+OriginalRef, plain SHA, depth ordering)
- `test/e2e/git_test.go` — `TestGitFetchOptimizations`: verifies targeted fetch line in `--json` output, locked sync uses OriginalRef, tampered lock SHA is detected

## Testing

```bash
./hack/build.sh
go test ./pkg/vendir/fetch/git/... -v
VENDIR_BINARY_PATH=./vendir go test ./test/e2e/... -v -run TestGitFetchOptimizations
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)