### PR TITLE
Suppress "Succeeded" line after vendir completion output

### DIFF
--- a/cmd/vendir/vendir.go
+++ b/cmd/vendir/vendir.go
@@ -13,6 +13,7 @@ import (
 	"carvel.dev/vendir/pkg/vendir/cmd"
 	uierrs "github.com/cppforlife/go-cli-ui/errors"
 	"github.com/cppforlife/go-cli-ui/ui"
+	"github.com/spf13/cobra"
 )
 
 func main() {
@@ -28,11 +29,20 @@ func main() {
 
 	command := cmd.NewDefaultVendirCmd(confUI)
 
-	err := command.Execute()
+	executedCmd, err := command.ExecuteC()
 	if err != nil {
 		confUI.ErrorLinef("vendir: Error: %v", uierrs.NewMultiLineError(err))
 		os.Exit(1)
 	}
 
-	confUI.PrintLinef("Succeeded")
+	// The "completion" command (and its shell subcommands) prints a script
+	// that is meant to be sourced/eval'd directly, so it must not be
+	// followed by any extra output.
+	if !isCompletionCmd(executedCmd) {
+		confUI.PrintLinef("Succeeded")
+	}
+}
+
+func isCompletionCmd(c *cobra.Command) bool {
+	return c.Name() == "completion" || (c.HasParent() && c.Parent().Name() == "completion")
 }

--- a/cmd/vendir/vendir.go
+++ b/cmd/vendir/vendir.go
@@ -43,6 +43,16 @@ func main() {
 	}
 }
 
+// isCompletionCmd reports whether the executed command is the "completion"
+// command (or one of its shell subcommands), or Cobra's hidden "__complete"
+// / "__completeNoDesc" command used to serve live shell completions. Output
+// from any of these must not be followed by extra text.
 func isCompletionCmd(c *cobra.Command) bool {
-	return c.Name() == "completion" || (c.HasParent() && c.Parent().Name() == "completion")
+	for ; c != nil; c = c.Parent() {
+		switch c.Name() {
+		case "completion", cobra.ShellCompRequestCmd:
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/vendir/vendir.go
+++ b/cmd/vendir/vendir.go
@@ -50,8 +50,11 @@ func main() {
 func isCompletionCmd(c *cobra.Command) bool {
 	for ; c != nil; c = c.Parent() {
 		switch c.Name() {
-		case "completion", cobra.ShellCompRequestCmd:
+		case "completion",
+			cobra.ShellCompRequestCmd,
+			cobra.ShellCompNoDescRequestCmd:
 			return true
+		default:
 		}
 	}
 	return false

--- a/cmd/vendir/vendir_test.go
+++ b/cmd/vendir/vendir_test.go
@@ -14,9 +14,10 @@ func TestIsCompletionCmd(t *testing.T) {
 	completion := &cobra.Command{Use: "completion"}
 	completionBash := &cobra.Command{Use: "bash"}
 	shellComplete := &cobra.Command{Use: cobra.ShellCompRequestCmd}
+	shellCompleteNoDesc := &cobra.Command{Use: cobra.ShellCompNoDescRequestCmd}
 	sync := &cobra.Command{Use: "sync"}
 
-	root.AddCommand(completion, shellComplete, sync)
+	root.AddCommand(completion, shellComplete, shellCompleteNoDesc, sync)
 	completion.AddCommand(completionBash)
 
 	cases := []struct {
@@ -28,6 +29,7 @@ func TestIsCompletionCmd(t *testing.T) {
 		{"completion command itself", completion, true},
 		{"completion shell subcommand", completionBash, true},
 		{"hidden __complete command", shellComplete, true},
+		{"hidden __completeNoDesc command", shellCompleteNoDesc, true},
 		{"unrelated command", sync, false},
 	}
 

--- a/cmd/vendir/vendir_test.go
+++ b/cmd/vendir/vendir_test.go
@@ -1,0 +1,41 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestIsCompletionCmd(t *testing.T) {
+	root := &cobra.Command{Use: "vendir"}
+	completion := &cobra.Command{Use: "completion"}
+	completionBash := &cobra.Command{Use: "bash"}
+	shellComplete := &cobra.Command{Use: cobra.ShellCompRequestCmd}
+	sync := &cobra.Command{Use: "sync"}
+
+	root.AddCommand(completion, shellComplete, sync)
+	completion.AddCommand(completionBash)
+
+	cases := []struct {
+		name string
+		cmd  *cobra.Command
+		want bool
+	}{
+		{"nil command", nil, false},
+		{"completion command itself", completion, true},
+		{"completion shell subcommand", completionBash, true},
+		{"hidden __complete command", shellComplete, true},
+		{"unrelated command", sync, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isCompletionCmd(c.cmd); got != c.want {
+				t.Errorf("isCompletionCmd(%v) = %v, want %v", c.cmd, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Motivation:
`vendir completion bash` (and zsh/fish/powershell) prints a shell
script to stdout that is meant to be sourced or eval'd directly, e.g.
`source <(vendir completion bash)`. main() unconditionally printed a
trailing "Succeeded" line after every command, including completion,
so the sourced script ended with a bare `Succeeded` token, which the
shell then tried to execute as a command.

Approach:
main() now captures the actually-executed *cobra.Command via
command.ExecuteC() (Execute() is just ExecuteC() with the command
discarded, so this is behavior-preserving for every other command)
and skips the "Succeeded" line when the executed command is cobra's
built-in "completion" command or one of its bash/zsh/fish/powershell
subcommands. vendir does not define its own completion command, so
this only affects cobra's default completion tree.

An initial attempt mirrored the fix already applied in carvel-dev/kapp
(cmd/kapp/kapp.go), which guards the same print with
cobrautil.IsCobraManagedCommand(os.Args). Building and testing that
approach against this issue showed it does not actually suppress the
line for `completion bash`: IsCobraManagedCommand only special-cases
"help", "__complete" and "__completeNoDesc", not "completion" itself,
so it does not resolve this report.

Validation:
- go build ./...
- ./hack/test.sh (repo's documented unit test script) - all packages
  pass; this code path has no existing unit tests.
- ./hack/build.sh (repo's documented build script: go mod
  vendor/tidy, go fmt, real build, `./vendir version`, compile-only
  `go test --exec=echo ./...`) - all steps pass.
- Manually built the binary before and after the change and compared:
  `vendir completion bash|zsh|fish|powershell | tail -n 3` no longer
  ends with "Succeeded" (it did before), while `vendir version` and
  an error path (`vendir sync -f /nonexistent.yml`, exit 1) are
  unaffected and still print/omit "Succeeded" as before.
- `bash -c 'source <(vendir completion bash) && echo SOURCE_OK'`
  succeeds after the fix, reproducing and resolving the exact failure
  mode from the report (it fails without the fix, since the shell
  tries to run the stray `Succeeded` token as a command).

User-visible behavior for every non-completion command is unchanged.

Report: https://github.com/carvel-dev/vendir/issues/405
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #405