### PR TITLE
fix: leave already up to date files untouched on sync

### DIFF
--- a/pkg/vendir/cmd/sync.go
+++ b/pkg/vendir/cmd/sync.go
@@ -28,9 +28,10 @@ type SyncOptions struct {
 	Files    []string
 	LockFile string
 
-	Directories []string
-	Locked      bool
-	Lazy        bool
+	Directories   []string
+	Locked        bool
+	Lazy          bool
+	MergeDiffOnly bool
 
 	Chdir                       string
 	AllowAllSymlinkDestinations bool
@@ -52,6 +53,7 @@ func NewSyncCmd(o *SyncOptions) *cobra.Command {
 	cmd.Flags().StringSliceVarP(&o.Directories, "directory", "d", nil, "Sync specific directory (format: dir/sub-dir[=local-dir])")
 	cmd.Flags().BoolVarP(&o.Locked, "locked", "l", false, "Consult lock file to pull exact references (e.g. use git sha instead of branch name)")
 	cmd.Flags().BoolVar(&o.Lazy, "lazy", true, "Set to 'false' it ignores the 'lazy' flag in the directory content configuration")
+	cmd.Flags().BoolVar(&o.MergeDiffOnly, "merge-diff-only", false, "Set to 'true' to only write contents that actually changed, leaving up to date files and manually managed contents untouched (slower, since every file is read back and compared)")
 
 	cmd.Flags().StringVar(&o.Chdir, "chdir", "", "Set current directory for process")
 	cmd.Flags().BoolVar(&o.AllowAllSymlinkDestinations, "dangerous-allow-all-symlink-destinations", false, "Symlinks to all destinations are allowed")
@@ -133,6 +135,7 @@ func (o *SyncOptions) Run() error {
 		HelmBinary:     os.Getenv("VENDIR_HELM_BINARY"),
 		Cache:          cache,
 		Lazy:           o.Lazy,
+		MergeDiffOnly:  o.MergeDiffOnly,
 		Partial:        len(dirs) > 0,
 	}
 	newLockConfig := ctlconf.NewLockConfig()

--- a/pkg/vendir/directory/directory.go
+++ b/pkg/vendir/directory/directory.go
@@ -71,6 +71,9 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 
 	defer stagingDir.CleanUp()
 
+	var contentPerms []pendingChmod
+	var unmanagedPaths []string
+
 	for _, contents := range d.opts.Contents {
 		stagingDstPath, err := stagingDir.NewChild(contents.Path)
 		if err != nil {
@@ -102,9 +105,6 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 			}
 			continue
 		}
-
-		skipFileFilter := false
-		skipNewRootPath := false
 
 		switch {
 		case contents.Git != nil:
@@ -195,16 +195,32 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 		case contents.Manual != nil:
 			d.ui.PrintLinef("Fetching: %s + %s (manual)", d.opts.Path, contents.Path)
 
+			// Manually managed contents are never staged, so that vendir does
+			// not have to move them out of the way and back, which would leave
+			// their parent directory looking modified
 			srcPath := filepath.Join(d.opts.Path, contents.Path)
 
-			err := os.Rename(srcPath, stagingDstPath)
+			_, err := os.Stat(srcPath)
 			if err != nil {
-				return lockConfig, fmt.Errorf("Moving directory '%s' to staging dir: %s", srcPath, err)
+				return lockConfig, fmt.Errorf(
+					"Checking manual directory '%s': %s", srcPath, err)
 			}
 
 			lockDirContents.Manual = &ctlconf.LockDirectoryContentsManual{}
-			skipFileFilter = true
-			skipNewRootPath = true
+			unmanagedPaths = append(unmanagedPaths, contents.Path)
+
+			perms := newPendingChmod(srcPath,
+				contents.Permissions, d.opts.Permissions)
+			contentPerms = append(contentPerms, perms)
+
+			// config digest is always added if lazy syncing is enabled
+			if contents.Lazy {
+				lockDirContents.ConfigDigest = configDigest
+			}
+
+			lockConfig.Contents = append(lockConfig.Contents, lockDirContents)
+
+			continue
 
 		case contents.Directory != nil:
 			d.ui.PrintLinef("Fetching: %s + %s (directory)", d.opts.Path, contents.Path)
@@ -230,14 +246,13 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 			return lockConfig, fmt.Errorf("Unknown contents type for directory '%s'", contents.Path)
 		}
 
-		if !skipFileFilter {
-			err = FileFilter{contents}.Apply(stagingDstPath)
-			if err != nil {
-				return lockConfig, fmt.Errorf("Filtering paths in directory '%s': %s", contents.Path, err)
-			}
+		err = FileFilter{contents}.Apply(stagingDstPath)
+		if err != nil {
+			return lockConfig, fmt.Errorf(
+				"Filtering paths in directory '%s': %s", contents.Path, err)
 		}
 
-		if !skipNewRootPath && len(contents.NewRootPath) > 0 {
+		if len(contents.NewRootPath) > 0 {
 			err = NewSubPath(contents.NewRootPath).Extract(stagingDstPath, stagingDstPath, stagingDir.TempArea())
 			if err != nil {
 				return lockConfig, fmt.Errorf("Changing to new root path '%s': %s", contents.Path, err)
@@ -250,12 +265,12 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 			return lockConfig, fmt.Errorf("Copying existing content to staging '%s': %s", d.opts.Path, err)
 		}
 
-		// after everything else is done, ensure the inner dir's access perms are set
-		// chmod to the content's permission, fall back to the directory's
-		err = maybeChmod(stagingDstPath, contents.Permissions, d.opts.Permissions)
-		if err != nil {
-			return lockConfig, fmt.Errorf("chmod on '%s': %s", stagingDstPath, err)
-		}
+		// perms are applied once the contents reached their final location,
+		// since restrictive ones would keep the staging dir from being read
+		// back. chmod to the content's permission, fall back to the directory's
+		contentPerms = append(contentPerms,
+			newPendingChmod(filepath.Join(d.opts.Path, contents.Path),
+				contents.Permissions, d.opts.Permissions))
 
 		// config digest is always added if lazy syncing is enabled in the config
 		if contents.Lazy {
@@ -273,9 +288,19 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 	}
 
 	if !syncOpts.Partial {
-		err = stagingDir.Replace(d.opts.Path)
+		err = stagingDir.Replace(d.opts.Path, unmanagedPaths)
 		if err != nil {
 			return lockConfig, err
+		}
+	}
+
+	// ensure the inner dirs' access perms are set before the outer dir's, since
+	// the latter may no longer allow descending into it
+	for _, pending := range contentPerms {
+		err = maybeChmod(pending.path, pending.potentialPerms...)
+		if err != nil {
+			return lockConfig, fmt.Errorf("chmod on '%s': %s",
+				pending.path, err)
 		}
 	}
 
@@ -286,6 +311,17 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 	}
 
 	return lockConfig, nil
+}
+
+// pendingChmod is a chmod that can only be carried out once the contents
+// reached their final location
+type pendingChmod struct {
+	path           string
+	potentialPerms []*os.FileMode
+}
+
+func newPendingChmod(path string, perms ...*os.FileMode) pendingChmod {
+	return pendingChmod{path: path, potentialPerms: perms}
 }
 
 // maybeChmod will chmod the path with the first non-nil permission provided.

--- a/pkg/vendir/directory/directory.go
+++ b/pkg/vendir/directory/directory.go
@@ -43,6 +43,7 @@ type SyncOpts struct {
 	HelmBinary     string
 	Cache          ctlcache.Cache
 	Lazy           bool
+	MergeDiffOnly  bool
 	Partial        bool
 }
 
@@ -59,7 +60,7 @@ func createConfigDigest(contents ctlconf.DirectoryContents) (string, error) {
 func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 	lockConfig := ctlconf.LockDirectory{Path: d.opts.Path}
 
-	stagingDir, err := NewStagingDir()
+	stagingDir, err := NewStagingDir(syncOpts.MergeDiffOnly)
 	if err != nil {
 		return lockConfig, err
 	}
@@ -105,6 +106,9 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 			}
 			continue
 		}
+
+		skipFileFilter := false
+		skipNewRootPath := false
 
 		switch {
 		case contents.Git != nil:
@@ -195,32 +199,45 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 		case contents.Manual != nil:
 			d.ui.PrintLinef("Fetching: %s + %s (manual)", d.opts.Path, contents.Path)
 
-			// Manually managed contents are never staged, so that vendir does
-			// not have to move them out of the way and back, which would leave
-			// their parent directory looking modified
 			srcPath := filepath.Join(d.opts.Path, contents.Path)
 
-			_, err := os.Stat(srcPath)
+			if syncOpts.MergeDiffOnly {
+				// Manually managed contents are never staged, so that vendir
+				// does not have to move them out of the way and back, which
+				// would leave their parent directory looking modified
+				_, err := os.Stat(srcPath)
+				if err != nil {
+					return lockConfig, fmt.Errorf(
+						"Checking manual directory '%s': %s", srcPath, err)
+				}
+
+				lockDirContents.Manual = &ctlconf.LockDirectoryContentsManual{}
+				unmanagedPaths = append(unmanagedPaths, contents.Path)
+
+				perms := newPendingChmod(srcPath,
+					contents.Permissions, d.opts.Permissions)
+				contentPerms = append(contentPerms, perms)
+
+				// config digest is always added if lazy syncing is enabled
+				if contents.Lazy {
+					lockDirContents.ConfigDigest = configDigest
+				}
+
+				lockConfig.Contents = append(lockConfig.Contents, lockDirContents)
+
+				continue
+			}
+
+			// The final location is swapped out as a whole, so the contents
+			// have to be moved into staging to survive
+			err := os.Rename(srcPath, stagingDstPath)
 			if err != nil {
-				return lockConfig, fmt.Errorf(
-					"Checking manual directory '%s': %s", srcPath, err)
+				return lockConfig, fmt.Errorf("Moving directory '%s' to staging dir: %s", srcPath, err)
 			}
 
 			lockDirContents.Manual = &ctlconf.LockDirectoryContentsManual{}
-			unmanagedPaths = append(unmanagedPaths, contents.Path)
-
-			perms := newPendingChmod(srcPath,
-				contents.Permissions, d.opts.Permissions)
-			contentPerms = append(contentPerms, perms)
-
-			// config digest is always added if lazy syncing is enabled
-			if contents.Lazy {
-				lockDirContents.ConfigDigest = configDigest
-			}
-
-			lockConfig.Contents = append(lockConfig.Contents, lockDirContents)
-
-			continue
+			skipFileFilter = true
+			skipNewRootPath = true
 
 		case contents.Directory != nil:
 			d.ui.PrintLinef("Fetching: %s + %s (directory)", d.opts.Path, contents.Path)
@@ -246,13 +263,15 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 			return lockConfig, fmt.Errorf("Unknown contents type for directory '%s'", contents.Path)
 		}
 
-		err = FileFilter{contents}.Apply(stagingDstPath)
-		if err != nil {
-			return lockConfig, fmt.Errorf(
-				"Filtering paths in directory '%s': %s", contents.Path, err)
+		if !skipFileFilter {
+			err = FileFilter{contents}.Apply(stagingDstPath)
+			if err != nil {
+				return lockConfig, fmt.Errorf(
+					"Filtering paths in directory '%s': %s", contents.Path, err)
+			}
 		}
 
-		if len(contents.NewRootPath) > 0 {
+		if !skipNewRootPath && len(contents.NewRootPath) > 0 {
 			err = NewSubPath(contents.NewRootPath).Extract(stagingDstPath, stagingDstPath, stagingDir.TempArea())
 			if err != nil {
 				return lockConfig, fmt.Errorf("Changing to new root path '%s': %s", contents.Path, err)
@@ -265,12 +284,22 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 			return lockConfig, fmt.Errorf("Copying existing content to staging '%s': %s", d.opts.Path, err)
 		}
 
-		// perms are applied once the contents reached their final location,
-		// since restrictive ones would keep the staging dir from being read
-		// back. chmod to the content's permission, fall back to the directory's
-		contentPerms = append(contentPerms,
-			newPendingChmod(filepath.Join(d.opts.Path, contents.Path),
-				contents.Permissions, d.opts.Permissions))
+		// chmod to the content's permission, fall back to the directory's
+		if syncOpts.MergeDiffOnly {
+			// perms are applied once the contents reached their final
+			// location, since restrictive ones would keep the staging dir
+			// from being read back
+			contentPerms = append(contentPerms,
+				newPendingChmod(filepath.Join(d.opts.Path, contents.Path),
+					contents.Permissions, d.opts.Permissions))
+		} else {
+			// after everything else is done, ensure the inner dir's access
+			// perms are set
+			err = maybeChmod(stagingDstPath, contents.Permissions, d.opts.Permissions)
+			if err != nil {
+				return lockConfig, fmt.Errorf("chmod on '%s': %s", stagingDstPath, err)
+			}
+		}
 
 		// config digest is always added if lazy syncing is enabled in the config
 		if contents.Lazy {
@@ -295,7 +324,8 @@ func (d *Directory) Sync(syncOpts SyncOpts) (ctlconf.LockDirectory, error) {
 	}
 
 	// ensure the inner dirs' access perms are set before the outer dir's, since
-	// the latter may no longer allow descending into it
+	// the latter may no longer allow descending into it. Nothing is pending
+	// unless diffs are merged, since otherwise staging is chmodded up front.
 	for _, pending := range contentPerms {
 		err = maybeChmod(pending.path, pending.potentialPerms...)
 		if err != nil {

--- a/pkg/vendir/directory/reconcile.go
+++ b/pkg/vendir/directory/reconcile.go
@@ -1,0 +1,320 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package directory
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// preservedPaths is a tree of path segments naming what vendir does not
+// manage within a reconciled dir, e.g. manually managed contents. Those are
+// neither deleted nor descended into.
+type preservedPaths map[string]preservedPaths
+
+func newPreservedPaths(paths []string) preservedPaths {
+	root := preservedPaths{}
+	for _, path := range paths {
+		root.add(path)
+	}
+
+	return root
+}
+
+func (p preservedPaths) add(path string) {
+	node := p
+	for _, segment := range strings.Split(filepath.ToSlash(path), "/") {
+		child, found := node[segment]
+		if !found {
+			child = preservedPaths{}
+			node[segment] = child
+		}
+		node = child
+	}
+}
+
+// reconcileDir makes the dir at dstPath hold exactly the contents of the dir
+// at srcPath, consuming srcPath in the process. Entries that already hold the
+// wanted contents are left in place instead of being written again, so that
+// their modification times stay stable for tooling that watches them.
+func reconcileDir(srcPath, dstPath string, preserved preservedPaths) error {
+	srcInfo, err := os.Lstat(srcPath)
+	if err != nil {
+		return fmt.Errorf("Reading staged dir '%s': %s", srcPath, err)
+	}
+
+	dstInfo, err := existingDir(dstPath)
+	if err != nil {
+		return err
+	}
+
+	// Nothing to compare against, and nothing to keep either since preserved
+	// paths only ever name contents that are already there, so the staged dir
+	// is moved over as a whole
+	if dstInfo == nil {
+		return moveEntry(srcPath, dstPath, nil)
+	}
+
+	err = reconcileDirEntries(srcPath, dstPath, preserved)
+	if err != nil {
+		return err
+	}
+
+	return maybeChmodTo(dstPath, dstInfo, srcInfo)
+}
+
+// existingDir returns the info of the dir at path, or nil when there is none.
+// Anything else found at path, e.g. a file or a symlink, is deleted, since it
+// cannot be updated in place.
+func existingDir(path string) (os.FileInfo, error) {
+	info, err := lstatOrNil(path)
+	if err != nil {
+		return nil, fmt.Errorf("Reading '%s': %s", path, err)
+	}
+	if info == nil {
+		return nil, nil
+	}
+	if info.IsDir() {
+		return info, nil
+	}
+
+	return nil, removePath(path)
+}
+
+func reconcileDirEntries(srcPath, dstPath string,
+	preserved preservedPaths) error {
+	srcEntries, err := os.ReadDir(srcPath)
+	if err != nil {
+		return fmt.Errorf("Reading staged dir '%s': %s", srcPath, err)
+	}
+
+	err = deleteStaleEntries(dstPath, keepNames(srcEntries, preserved))
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range srcEntries {
+		err := reconcileEntry(
+			filepath.Join(srcPath, entry.Name()),
+			filepath.Join(dstPath, entry.Name()),
+			preserved[entry.Name()])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// deleteStaleEntries drops everything within dstPath that is not to be kept
+func deleteStaleEntries(dstPath string, keep nameSet) error {
+	dstEntries, err := os.ReadDir(dstPath)
+	if err != nil {
+		return fmt.Errorf("Reading dir '%s': %s", dstPath, err)
+	}
+
+	for _, entry := range dstEntries {
+		if _, found := keep[entry.Name()]; found {
+			continue
+		}
+
+		err := removePath(filepath.Join(dstPath, entry.Name()))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// nameSet holds directory entry names
+type nameSet map[string]struct{}
+
+// keepNames returns the names that have to survive within the reconciled dir:
+// the staged ones plus the ones vendir does not manage
+func keepNames(staged []os.DirEntry, preserved preservedPaths) nameSet {
+	names := nameSet{}
+	for _, entry := range staged {
+		names[entry.Name()] = struct{}{}
+	}
+	for name := range preserved {
+		names[name] = struct{}{}
+	}
+
+	return names
+}
+
+func reconcileEntry(srcPath, dstPath string, preserved preservedPaths) error {
+	srcInfo, err := os.Lstat(srcPath)
+	if err != nil {
+		return fmt.Errorf("Reading staged '%s': %s", srcPath, err)
+	}
+
+	if srcInfo.IsDir() {
+		return reconcileDir(srcPath, dstPath, preserved)
+	}
+
+	dstInfo, err := lstatOrNil(dstPath)
+	if err != nil {
+		return fmt.Errorf("Reading '%s': %s", dstPath, err)
+	}
+
+	upToDate, err := sameEntry(srcPath, dstPath, srcInfo, dstInfo)
+	if err != nil {
+		return err
+	}
+	if upToDate {
+		return maybeChmodTo(dstPath, dstInfo, srcInfo)
+	}
+
+	return moveEntry(srcPath, dstPath, dstInfo)
+}
+
+// sameEntry reports whether the entry at dst already holds what the staged
+// entry at src has to offer, permissions aside
+func sameEntry(src, dst string, srcInfo, dstInfo os.FileInfo) (bool, error) {
+	switch {
+	case dstInfo == nil:
+		return false, nil
+
+	case srcInfo.Mode()&os.ModeSymlink != 0:
+		return sameSymlinkTarget(src, dst, dstInfo)
+
+	case srcInfo.Mode().IsRegular():
+		if !dstInfo.Mode().IsRegular() {
+			return false, nil
+		}
+		if dstInfo.Size() != srcInfo.Size() {
+			return false, nil
+		}
+
+		return sameFileContents(src, dst)
+
+	default:
+		// Anything else, e.g. a socket, is always moved over
+		return false, nil
+	}
+}
+
+// moveEntry moves the staged entry over the final location, carrying its
+// modification time along
+func moveEntry(srcPath, dstPath string, dstInfo os.FileInfo) error {
+	// Rename cannot replace a dir, and on Windows not an existing file either
+	if dstInfo != nil {
+		err := removePath(dstPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := os.Rename(srcPath, dstPath)
+	if err != nil {
+		return fmt.Errorf("Moving staged '%s' to '%s': %s",
+			srcPath, dstPath, err)
+	}
+
+	return nil
+}
+
+// sameFileContents reports whether both files hold the same bytes.
+// Permissions are deliberately left out, since they can be changed without
+// writing the file again.
+func sameFileContents(src, dst string) (bool, error) {
+	srcSum, err := fileSum(src)
+	if err != nil {
+		return false, err
+	}
+
+	dstSum, err := fileSum(dst)
+	if err != nil {
+		return false, err
+	}
+
+	return srcSum == dstSum, nil
+}
+
+func fileSum(path string) ([sha256.Size]byte, error) {
+	var sum [sha256.Size]byte
+
+	file, err := os.Open(path)
+	if err != nil {
+		return sum, fmt.Errorf("Opening file '%s': %s", path, err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return sum, fmt.Errorf("Reading file '%s': %s", path, err)
+	}
+
+	return [sha256.Size]byte(hash.Sum(nil)), nil
+}
+
+func sameSymlinkTarget(src, dst string, dstInfo os.FileInfo) (bool, error) {
+	if dstInfo.Mode()&os.ModeSymlink == 0 {
+		return false, nil
+	}
+
+	srcTarget, err := os.Readlink(src)
+	if err != nil {
+		return false, fmt.Errorf("Reading staged symlink '%s': %s", src, err)
+	}
+
+	dstTarget, err := os.Readlink(dst)
+	if err != nil {
+		return false, fmt.Errorf("Reading symlink '%s': %s", dst, err)
+	}
+
+	return srcTarget == dstTarget, nil
+}
+
+// maybeChmodTo aligns the permissions of an entry that was left in place with
+// the staged ones
+func maybeChmodTo(dstPath string, dstInfo, srcInfo os.FileInfo) error {
+	// A chmod would follow the link and touch its target instead
+	if srcInfo.Mode()&os.ModeSymlink != 0 {
+		return nil
+	}
+
+	if dstInfo.Mode().Perm() == srcInfo.Mode().Perm() {
+		return nil
+	}
+
+	err := os.Chmod(dstPath, srcInfo.Mode().Perm())
+	if err != nil {
+		return fmt.Errorf("Chmod on '%s': %s", dstPath, err)
+	}
+
+	return nil
+}
+
+func removePath(path string) error {
+	err := os.RemoveAll(path)
+	if err != nil {
+		return fmt.Errorf("Deleting '%s': %s", path, err)
+	}
+
+	return nil
+}
+
+// lstatOrNil returns a nil FileInfo, and no error, when path does not exist
+func lstatOrNil(path string) (os.FileInfo, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
+}

--- a/pkg/vendir/directory/reconcile_test.go
+++ b/pkg/vendir/directory/reconcile_test.go
@@ -1,0 +1,303 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package directory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testFilePerms  = os.FileMode(0600)
+	testDirPerms   = os.FileMode(0700)
+	testGroupPerms = os.FileMode(0640)
+	testOtherPerms = os.FileMode(0750)
+
+	unchangedContents = "unchanged contents"
+	addedContents     = "added contents"
+)
+
+func TestReconcileDirLeavesUnchangedEntriesUntouched(t *testing.T) {
+	src, dst := t.TempDir(), t.TempDir()
+
+	kept, nested := "kept.yml", filepath.Join("nested", "kept.yml")
+
+	writeFile(t, dst, kept, unchangedContents)
+	writeFile(t, dst, nested, unchangedContents)
+	writeFile(t, src, kept, unchangedContents)
+	writeFile(t, src, nested, unchangedContents)
+
+	before := modTimes(t, dst)
+
+	require.NoError(t, reconcileDir(src, dst, nil))
+
+	require.Equal(t, before, modTimes(t, dst))
+}
+
+func TestReconcileDirRewritesChangedFiles(t *testing.T) {
+	changed := "changed.yml"
+
+	t.Run("contents of a different length", func(t *testing.T) {
+		src, dst := t.TempDir(), t.TempDir()
+
+		writeFile(t, dst, changed, "old")
+		writeFile(t, src, changed, "new contents")
+
+		before := modTimes(t, dst)
+
+		require.NoError(t, reconcileDir(src, dst, nil))
+
+		require.Equal(t, "new contents", readFile(t, dst, changed))
+		require.NotEqual(t, before, modTimes(t, dst))
+	})
+
+	t.Run("contents of the same length", func(t *testing.T) {
+		src, dst := t.TempDir(), t.TempDir()
+
+		writeFile(t, dst, changed, "abc")
+		writeFile(t, src, changed, "abd")
+
+		require.NoError(t, reconcileDir(src, dst, nil))
+
+		require.Equal(t, "abd", readFile(t, dst, changed))
+	})
+}
+
+func TestReconcileDirAddsAndDeletesEntries(t *testing.T) {
+	src, dst := t.TempDir(), t.TempDir()
+
+	staleFile, staleDir := "stale.yml", "stale-dir"
+	added := filepath.Join("new-dir", "new.yml")
+
+	writeFile(t, dst, filepath.Join(staleDir, staleFile), "stale")
+	writeFile(t, dst, staleFile, "stale")
+	writeFile(t, src, added, addedContents)
+
+	require.NoError(t, reconcileDir(src, dst, nil))
+
+	require.NoFileExists(t, filepath.Join(dst, staleFile))
+	require.NoDirExists(t, filepath.Join(dst, staleDir))
+	require.Equal(t, addedContents, readFile(t, dst, added))
+}
+
+func TestReconcileDirKeepsPreservedPaths(t *testing.T) {
+	t.Run("at the top level", func(t *testing.T) {
+		src, dst := t.TempDir(), t.TempDir()
+
+		unmanaged := "unmanaged"
+
+		writeFile(t, dst, filepath.Join(unmanaged, "mine.yml"), unchangedContents)
+		writeFile(t, src, "staged.yml", addedContents)
+
+		before := modTimes(t, filepath.Join(dst, unmanaged))
+
+		preserved := newPreservedPaths([]string{unmanaged})
+		require.NoError(t, reconcileDir(src, dst, preserved))
+
+		require.Equal(t, before, modTimes(t, filepath.Join(dst, unmanaged)))
+		require.Equal(t, addedContents, readFile(t, dst, "staged.yml"))
+	})
+
+	t.Run("nested next to staged contents", func(t *testing.T) {
+		src, dst := t.TempDir(), t.TempDir()
+
+		unmanaged := filepath.Join("group", "unmanaged")
+		staged := filepath.Join("group", "staged")
+
+		writeFile(t, dst, filepath.Join(unmanaged, "mine.yml"), unchangedContents)
+		writeFile(t, dst, filepath.Join(staged, "stale.yml"), "stale")
+		writeFile(t, src, filepath.Join(staged, "fresh.yml"), addedContents)
+
+		before := modTimes(t, filepath.Join(dst, unmanaged))
+
+		preserved := newPreservedPaths([]string{unmanaged})
+		require.NoError(t, reconcileDir(src, dst, preserved))
+
+		require.Equal(t, before, modTimes(t, filepath.Join(dst, unmanaged)))
+		require.NoFileExists(t, filepath.Join(dst, staged, "stale.yml"))
+		require.Equal(t, addedContents,
+			readFile(t, dst, filepath.Join(staged, "fresh.yml")))
+	})
+
+	t.Run("below a dir that holds nothing staged", func(t *testing.T) {
+		src, dst := t.TempDir(), t.TempDir()
+
+		unmanaged := filepath.Join("group", "unmanaged")
+
+		writeFile(t, dst, filepath.Join(unmanaged, "mine.yml"), unchangedContents)
+		writeFile(t, dst, filepath.Join("group", "stale.yml"), "stale")
+		require.NoError(t, os.Mkdir(filepath.Join(src, "group"), testDirPerms))
+
+		before := modTimes(t, filepath.Join(dst, unmanaged))
+
+		preserved := newPreservedPaths([]string{unmanaged})
+		require.NoError(t, reconcileDir(src, dst, preserved))
+
+		require.Equal(t, before, modTimes(t, filepath.Join(dst, unmanaged)))
+		require.NoFileExists(t, filepath.Join(dst, "group", "stale.yml"))
+	})
+}
+
+func TestReconcileDirReplacesEntriesWhoseTypeChanged(t *testing.T) {
+	src, dst := t.TempDir(), t.TempDir()
+
+	becameDir, becameFile := "became-dir", "became-file"
+	nested := filepath.Join(becameDir, "nested.yml")
+
+	writeFile(t, dst, becameDir, "leftover file")
+	writeFile(t, src, nested, "nested contents")
+	writeFile(t, dst, filepath.Join(becameFile, "nested.yml"), "leftover dir")
+	writeFile(t, src, becameFile, "file contents")
+
+	require.NoError(t, reconcileDir(src, dst, nil))
+
+	require.Equal(t, "nested contents", readFile(t, dst, nested))
+	require.Equal(t, "file contents", readFile(t, dst, becameFile))
+}
+
+func TestReconcileDirDoesNotWriteThroughLeftOverSymlinks(t *testing.T) {
+	src, dst, outside := t.TempDir(), t.TempDir(), t.TempDir()
+
+	planted := filepath.Join("escape", "planted.yml")
+
+	require.NoError(t, os.Symlink(outside, filepath.Join(dst, "escape")))
+	writeFile(t, src, planted, "planted")
+
+	require.NoError(t, reconcileDir(src, dst, nil))
+
+	require.Equal(t, "planted", readFile(t, dst, planted))
+	require.NoFileExists(t, filepath.Join(outside, "planted.yml"))
+}
+
+func TestReconcileDirWithSymlinks(t *testing.T) {
+	link := "link"
+
+	t.Run("same target is left untouched", func(t *testing.T) {
+		src, dst := t.TempDir(), t.TempDir()
+
+		target := "target.yml"
+
+		writeFile(t, src, target, "target")
+		writeFile(t, dst, target, "target")
+		require.NoError(t, os.Symlink(target, filepath.Join(src, link)))
+		require.NoError(t, os.Symlink(target, filepath.Join(dst, link)))
+
+		before := modTimes(t, dst)
+
+		require.NoError(t, reconcileDir(src, dst, nil))
+
+		require.Equal(t, before, modTimes(t, dst))
+	})
+
+	t.Run("different target is updated", func(t *testing.T) {
+		src, dst := t.TempDir(), t.TempDir()
+
+		staged := "staged-target.yml"
+
+		require.NoError(t, os.Symlink("old-target.yml", filepath.Join(dst, link)))
+		require.NoError(t, os.Symlink(staged, filepath.Join(src, link)))
+
+		require.NoError(t, reconcileDir(src, dst, nil))
+
+		target, err := os.Readlink(filepath.Join(dst, link))
+		require.NoError(t, err)
+		require.Equal(t, staged, target)
+	})
+}
+
+func TestReconcileDirAlignsPermissionsWithoutRewriting(t *testing.T) {
+	src, dst := t.TempDir(), t.TempDir()
+
+	unchanged := "unchanged.yml"
+
+	writeFile(t, src, unchanged, unchangedContents)
+	writeFile(t, dst, unchanged, unchangedContents)
+	require.NoError(t, os.Chmod(filepath.Join(src, unchanged), testGroupPerms))
+
+	before := modTimes(t, dst)
+
+	require.NoError(t, reconcileDir(src, dst, nil))
+
+	require.Equal(t, before, modTimes(t, dst))
+
+	info, err := os.Stat(filepath.Join(dst, unchanged))
+	require.NoError(t, err)
+	require.Equal(t, testGroupPerms, info.Mode().Perm())
+}
+
+func TestReconcileDirCreatesMissingFinalLocation(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "missing")
+
+	added := "added.yml"
+
+	writeFile(t, src, added, addedContents)
+	require.NoError(t, os.Chmod(src, testOtherPerms))
+
+	require.NoError(t, reconcileDir(src, dst, nil))
+
+	require.Equal(t, addedContents, readFile(t, dst, added))
+
+	info, err := os.Stat(dst)
+	require.NoError(t, err)
+	require.Equal(t, testOtherPerms, info.Mode().Perm())
+}
+
+func TestReconcileDirKeepsStagedModTimeOfMovedEntries(t *testing.T) {
+	src, dst := t.TempDir(), t.TempDir()
+
+	moved := "moved.yml"
+
+	writeFile(t, src, moved, "moved")
+	staged := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	require.NoError(t, os.Chtimes(filepath.Join(src, moved), staged, staged))
+
+	require.NoError(t, reconcileDir(src, dst, nil))
+
+	info, err := os.Stat(filepath.Join(dst, moved))
+	require.NoError(t, err)
+	require.True(t, info.ModTime().Equal(staged),
+		"expected mod time %s, got %s", staged, info.ModTime())
+}
+
+func writeFile(t *testing.T, dir, path, contents string) {
+	t.Helper()
+
+	fullPath := filepath.Join(dir, path)
+	require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), testDirPerms))
+	require.NoError(t, os.WriteFile(fullPath, []byte(contents), testFilePerms))
+}
+
+func readFile(t *testing.T, dir, path string) string {
+	t.Helper()
+
+	bs, err := os.ReadFile(filepath.Join(dir, path))
+	require.NoError(t, err)
+
+	return string(bs)
+}
+
+// modTimes collects the modification time of every entry below dir, keyed by
+// its path relative to dir
+func modTimes(t *testing.T, dir string) map[string]time.Time {
+	t.Helper()
+
+	times := map[string]time.Time{}
+
+	require.NoError(t, filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		require.NoError(t, err)
+
+		relPath, err := filepath.Rel(dir, path)
+		require.NoError(t, err)
+		times[relPath] = info.ModTime()
+
+		return nil
+	}))
+
+	return times
+}

--- a/pkg/vendir/directory/staging_dir.go
+++ b/pkg/vendir/directory/staging_dir.go
@@ -19,20 +19,22 @@ import (
 const stagingDirPerms os.FileMode = 0700
 
 type StagingDir struct {
-	rootDir     string
-	stagingDir  string
-	incomingDir string
+	rootDir       string
+	stagingDir    string
+	incomingDir   string
+	mergeDiffOnly bool
 }
 
-func NewStagingDir() (StagingDir, error) {
+func NewStagingDir(mergeDiffOnly bool) (StagingDir, error) {
 	rootDir, err := os.MkdirTemp(".", ".vendir-tmp-")
 	if err != nil {
 		return StagingDir{}, err
 	}
 	return StagingDir{
-		rootDir:     rootDir,
-		stagingDir:  filepath.Join(rootDir, "staging"),
-		incomingDir: filepath.Join(rootDir, "incoming"),
+		rootDir:       rootDir,
+		stagingDir:    filepath.Join(rootDir, "staging"),
+		incomingDir:   filepath.Join(rootDir, "incoming"),
+		mergeDiffOnly: mergeDiffOnly,
 	}, nil
 }
 
@@ -133,15 +135,16 @@ func isPathIgnored(path string, ignorePaths []string) (bool, error) {
 }
 
 // Replace makes the entire final location directory hold the staging
-// directory's contents. Files that already hold those are left untouched, and
-// so are the unmanaged paths, given relative to the final location.
+// directory's contents. When merging diffs only, files that already hold those
+// are left untouched, and so are the unmanaged paths, given relative to the
+// final location; otherwise the whole directory is swapped over.
 func (d StagingDir) Replace(path string, unmanagedPaths []string) error {
 	err := d.prepareOutputDirectory(path)
 	if err != nil {
 		return err
 	}
 
-	err = reconcileDir(d.stagingDir, path, newPreservedPaths(unmanagedPaths))
+	err = d.materialize(d.stagingDir, path, newPreservedPaths(unmanagedPaths))
 	if err != nil {
 		return fmt.Errorf("Moving staging directory '%s' to final location '%s': %s", d.stagingDir, path, err)
 	}
@@ -150,8 +153,8 @@ func (d StagingDir) Replace(path string, unmanagedPaths []string) error {
 }
 
 // PartialRepace makes a single directory of the final location dir hold the
-// matching staging dir's contents. Files that already hold those are left
-// untouched.
+// matching staging dir's contents. When merging diffs only, files that already
+// hold those are left untouched; otherwise the directory is swapped over.
 func (d StagingDir) PartialRepace(contentPath string, directoryPath string) error {
 	err := d.prepareOutputDirectory(directoryPath)
 	if err != nil {
@@ -160,7 +163,7 @@ func (d StagingDir) PartialRepace(contentPath string, directoryPath string) erro
 
 	stagedPath := filepath.Join(d.stagingDir, contentPath)
 
-	err = reconcileDir(stagedPath, directoryPath, nil)
+	err = d.materialize(stagedPath, directoryPath, nil)
 	if err != nil {
 		return fmt.Errorf("Moving staging directory '%s' to final location '%s': %s", d.stagingDir, directoryPath, err)
 	}
@@ -168,7 +171,26 @@ func (d StagingDir) PartialRepace(contentPath string, directoryPath string) erro
 	return nil
 }
 
+// materialize makes the dir at dstPath hold what is staged at srcPath,
+// consuming srcPath in the process
+func (d StagingDir) materialize(srcPath, dstPath string, preserved preservedPaths) error {
+	if !d.mergeDiffOnly {
+		return os.Rename(srcPath, dstPath)
+	}
+
+	return reconcileDir(srcPath, dstPath, preserved)
+}
+
 func (d StagingDir) prepareOutputDirectory(directoryPath string) error {
+	// the whole final location is swapped out, so whatever is there has to go
+	// first; when merging diffs only it is reconciled in place instead
+	if !d.mergeDiffOnly {
+		err := os.RemoveAll(directoryPath)
+		if err != nil {
+			return fmt.Errorf("Deleting dir %s: %s", directoryPath, err)
+		}
+	}
+
 	// Clean to avoid getting 'out/in/' from 'out/in/' instead of just 'out'
 	parentPath := filepath.Dir(filepath.Clean(directoryPath))
 

--- a/pkg/vendir/directory/staging_dir.go
+++ b/pkg/vendir/directory/staging_dir.go
@@ -14,6 +14,10 @@ import (
 	"github.com/bmatcuk/doublestar"
 )
 
+// stagingDirPerms are the permissions directories are created with while
+// vendir owns them, before the configured ones are applied
+const stagingDirPerms os.FileMode = 0700
+
 type StagingDir struct {
 	rootDir     string
 	stagingDir  string
@@ -128,15 +132,16 @@ func isPathIgnored(path string, ignorePaths []string) (bool, error) {
 	return false, nil
 }
 
-// Replaces entire final location directory with staging directory
-func (d StagingDir) Replace(path string) error {
-
+// Replace makes the entire final location directory hold the staging
+// directory's contents. Files that already hold those are left untouched, and
+// so are the unmanaged paths, given relative to the final location.
+func (d StagingDir) Replace(path string, unmanagedPaths []string) error {
 	err := d.prepareOutputDirectory(path)
 	if err != nil {
 		return err
 	}
 
-	err = os.Rename(d.stagingDir, path)
+	err = reconcileDir(d.stagingDir, path, newPreservedPaths(unmanagedPaths))
 	if err != nil {
 		return fmt.Errorf("Moving staging directory '%s' to final location '%s': %s", d.stagingDir, path, err)
 	}
@@ -144,14 +149,18 @@ func (d StagingDir) Replace(path string) error {
 	return nil
 }
 
-// Replaces single directory of final location dir with single directory of staging dir
+// PartialRepace makes a single directory of the final location dir hold the
+// matching staging dir's contents. Files that already hold those are left
+// untouched.
 func (d StagingDir) PartialRepace(contentPath string, directoryPath string) error {
 	err := d.prepareOutputDirectory(directoryPath)
 	if err != nil {
 		return err
 	}
 
-	err = os.Rename(filepath.Join(d.stagingDir, contentPath), directoryPath)
+	stagedPath := filepath.Join(d.stagingDir, contentPath)
+
+	err = reconcileDir(stagedPath, directoryPath, nil)
 	if err != nil {
 		return fmt.Errorf("Moving staging directory '%s' to final location '%s': %s", d.stagingDir, directoryPath, err)
 	}
@@ -160,15 +169,10 @@ func (d StagingDir) PartialRepace(contentPath string, directoryPath string) erro
 }
 
 func (d StagingDir) prepareOutputDirectory(directoryPath string) error {
-	err := os.RemoveAll(directoryPath)
-	if err != nil {
-		return fmt.Errorf("Deleting dir %s: %s", directoryPath, err)
-	}
-
 	// Clean to avoid getting 'out/in/' from 'out/in/' instead of just 'out'
 	parentPath := filepath.Dir(filepath.Clean(directoryPath))
 
-	err = os.MkdirAll(parentPath, 0700)
+	err := os.MkdirAll(parentPath, stagingDirPerms)
 	if err != nil {
 		return fmt.Errorf("Creating final location parent dir %s: %s", parentPath, err)
 	}

--- a/test/e2e/merge_diff_only_test.go
+++ b/test/e2e/merge_diff_only_test.go
@@ -1,0 +1,287 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"carvel.dev/vendir/pkg/vendir/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	vendorPath = "vendor"
+	inlinePath = "vendor/inline"
+	manualPath = "vendor/manual"
+
+	manualFilePath = "vendor/manual/kept.txt"
+	inlineFilePath = "vendor/inline/bar.yml"
+
+	manualFileContents = "manually managed"
+)
+
+// TestMergeDiffOnlyLeavesUpToDateContentsUntouched asserts that a resync which
+// has nothing new to offer does not rewrite what is already there
+func TestMergeDiffOnlyLeavesUpToDateContentsUntouched(t *testing.T) {
+	env := BuildEnv(t)
+	vendir := Vendir{t, env.BinaryPath, Logger{}}
+
+	tmpDir := setUpMergeDiffOnlyDir(t, mergeDiffOnlyConfig())
+
+	syncMergeDiffOnly(t, vendir, tmpDir)
+	firstSync := modTimes(t, tmpDir, vendorPath, inlinePath, manualPath, inlineFilePath, manualFilePath)
+
+	syncMergeDiffOnly(t, vendir, tmpDir)
+	secondSync := modTimes(t, tmpDir, vendorPath, inlinePath, manualPath, inlineFilePath, manualFilePath)
+
+	assert.Equal(t, firstSync, secondSync,
+		"expected an up to date sync to leave every path untouched")
+
+	assertFileContents(t, tmpDir, manualFilePath, manualFileContents)
+	assertFileContents(t, tmpDir, inlineFilePath, "bar")
+}
+
+// TestMergeDiffOnlyWritesChangedContents asserts that leaving up to date files
+// alone does not keep the changed ones from being written
+func TestMergeDiffOnlyWritesChangedContents(t *testing.T) {
+	env := BuildEnv(t)
+	vendir := Vendir{t, env.BinaryPath, Logger{}}
+
+	cfg := mergeDiffOnlyConfig()
+	tmpDir := setUpMergeDiffOnlyDir(t, cfg)
+
+	syncMergeDiffOnly(t, vendir, tmpDir)
+	firstSync := modTimes(t, tmpDir, inlineFilePath, manualFilePath)
+
+	cfg.Directories[0].Contents[0].Inline.Paths["bar.yml"] = "bar-updated"
+	writeConfigFile(t, tmpDir, *cfg)
+
+	syncMergeDiffOnly(t, vendir, tmpDir)
+	secondSync := modTimes(t, tmpDir, inlineFilePath, manualFilePath)
+
+	assert.NotEqual(t, firstSync[inlineFilePath], secondSync[inlineFilePath],
+		"expected the changed inline file to be written again")
+	assert.Equal(t, firstSync[manualFilePath], secondSync[manualFilePath],
+		"expected the manual contents to stay untouched")
+
+	assertFileContents(t, tmpDir, inlineFilePath, "bar-updated")
+	assertFileContents(t, tmpDir, manualFilePath, manualFileContents)
+}
+
+// TestMergeDiffOnlyPreservesManualContents asserts that contents vendir does
+// not manage survive a sync that removes stale entries around them
+func TestMergeDiffOnlyPreservesManualContents(t *testing.T) {
+	env := BuildEnv(t)
+	vendir := Vendir{t, env.BinaryPath, Logger{}}
+
+	tmpDir := setUpMergeDiffOnlyDir(t, mergeDiffOnlyConfig())
+
+	syncMergeDiffOnly(t, vendir, tmpDir)
+
+	// something vendir does not know about, next to the managed contents
+	stalePath := filepath.Join(tmpDir, vendorPath, "stale")
+	require.NoError(t, os.MkdirAll(stalePath, 0700), "creating stale dir")
+
+	// and something the user added to the manual contents in the meantime
+	addedPath := filepath.Join(tmpDir, manualPath, "added.txt")
+	require.NoError(t, os.WriteFile(addedPath, []byte("added"), 0600), "writing added file")
+
+	syncMergeDiffOnly(t, vendir, tmpDir)
+
+	assert.NoDirExists(t, stalePath, "expected the stale dir to be dropped")
+	assertFileContents(t, tmpDir, manualFilePath, manualFileContents)
+	assertFileContents(t, tmpDir, filepath.Join(manualPath, "added.txt"), "added")
+}
+
+// TestMergeDiffOnlyAppliesPermissions asserts that permissions still land on
+// the final location, including on contents vendir does not manage and on
+// contents whose permissions keep them from being read back
+func TestMergeDiffOnlyAppliesPermissions(t *testing.T) {
+	env := BuildEnv(t)
+	vendir := Vendir{t, env.BinaryPath, Logger{}}
+
+	tCases := map[string]struct {
+		updateConfig  func(cfg *config.Config)
+		expectedPerms filePerms
+	}{
+		"no permissions defined": {
+			expectedPerms: filePerms{vendorPath: 0700, inlinePath: 0700, manualPath: 0700},
+		},
+		"outer dir permissions apply to manual contents too": {
+			updateConfig: func(c *config.Config) {
+				c.Directories[0].Permissions = p(0744)
+			},
+			expectedPerms: filePerms{vendorPath: 0744, inlinePath: 0744, manualPath: 0744},
+		},
+		"inner dir permissions can be configured": {
+			updateConfig: func(c *config.Config) {
+				c.Directories[0].Contents[0].Permissions = p(0755)
+				c.Directories[0].Contents[1].Permissions = p(0750)
+			},
+			expectedPerms: filePerms{vendorPath: 0700, inlinePath: 0755, manualPath: 0750},
+		},
+		"blocking reads in inner dirs still works": {
+			updateConfig: func(c *config.Config) {
+				c.Directories[0].Contents[0].Permissions = p(0100)
+				c.Directories[0].Contents[1].Permissions = p(0100)
+			},
+			expectedPerms: filePerms{vendorPath: 0700, inlinePath: 0100, manualPath: 0100},
+		},
+	}
+
+	for tName, tCase := range tCases {
+		t.Run(tName, func(t *testing.T) {
+			cfg := mergeDiffOnlyConfig()
+
+			if u := tCase.updateConfig; u != nil {
+				u(cfg)
+			}
+
+			tmpDir := setUpMergeDiffOnlyDir(t, cfg)
+			syncMergeDiffOnly(t, vendir, tmpDir)
+
+			actual := filePerms{}
+			for path := range tCase.expectedPerms {
+				actual[path] = getPerms(t, filepath.Join(tmpDir, path))
+			}
+
+			tCase.expectedPerms.validate(t, actual)
+		})
+	}
+}
+
+// TestSyncWithoutMergeDiffOnlyReplacesDirectory asserts that the default keeps
+// swapping the whole directory over, staging the manual contents along the way
+func TestSyncWithoutMergeDiffOnlyReplacesDirectory(t *testing.T) {
+	env := BuildEnv(t)
+	vendir := Vendir{t, env.BinaryPath, Logger{}}
+
+	cfg := mergeDiffOnlyConfig()
+	cfg.Directories[0].Contents[0].Permissions = p(0755)
+	cfg.Directories[0].Contents[1].Permissions = p(0750)
+
+	tmpDir := setUpMergeDiffOnlyDir(t, cfg)
+
+	syncDefault(t, vendir, tmpDir)
+	firstSync := modTimes(t, tmpDir, inlineFilePath)
+
+	// the manual contents have to survive the round trip through staging
+	assertFileContents(t, tmpDir, manualFilePath, manualFileContents)
+
+	syncDefault(t, vendir, tmpDir)
+	secondSync := modTimes(t, tmpDir, inlineFilePath)
+
+	assert.NotEqual(t, firstSync[inlineFilePath], secondSync[inlineFilePath],
+		"expected the default to write every file again")
+
+	assertFileContents(t, tmpDir, manualFilePath, manualFileContents)
+
+	filePerms{inlinePath: 0755, manualPath: 0750}.validate(t, filePerms{
+		inlinePath: getPerms(t, filepath.Join(tmpDir, inlinePath)),
+		manualPath: getPerms(t, filepath.Join(tmpDir, manualPath)),
+	})
+}
+
+// mergeDiffOnlyConfig returns a config with one vendir managed content and one
+// manually managed one, so that both branches are exercised side by side
+func mergeDiffOnlyConfig() *config.Config {
+	return &config.Config{
+		APIVersion: "vendir.k14s.io/v1alpha1",
+		Kind:       "Config",
+		Directories: []config.Directory{
+			{
+				Path: vendorPath,
+				Contents: []config.DirectoryContents{
+					{
+						Path: "inline",
+						Inline: &config.DirectoryContentsInline{
+							Paths: map[string]string{"bar.yml": "bar"},
+						},
+					},
+					{
+						Path:   "manual",
+						Manual: &config.DirectoryContentsManual{},
+					},
+				},
+			},
+		},
+	}
+}
+
+// setUpMergeDiffOnlyDir returns a directory holding the given config plus the
+// manually managed contents it refers to
+func setUpMergeDiffOnlyDir(t *testing.T, cfg *config.Config) string {
+	tmpDir := t.TempDir()
+
+	writeConfigFile(t, tmpDir, *cfg)
+
+	err := os.MkdirAll(filepath.Join(tmpDir, manualPath), 0700)
+	require.NoError(t, err, "creating manual contents dir")
+
+	err = os.WriteFile(filepath.Join(tmpDir, manualFilePath),
+		[]byte(manualFileContents), 0600)
+	require.NoError(t, err, "writing manual contents")
+
+	// configured permissions may keep the tmp dir from being cleaned up again
+	t.Cleanup(func() { chmodTreeAccessible(filepath.Join(tmpDir, vendorPath)) })
+
+	return tmpDir
+}
+
+// chmodTreeAccessible makes path and every dir below it readable again. Each
+// dir is chmodded before it is read, so that restrictive permissions do not
+// keep the tree from being descended into.
+func chmodTreeAccessible(path string) {
+	os.Chmod(path, 0700)
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			chmodTreeAccessible(filepath.Join(path, entry.Name()))
+		}
+	}
+}
+
+func syncDefault(t *testing.T, vendir Vendir, dir string) {
+	t.Helper()
+	_, err := vendir.RunWithOpts([]string{"sync"}, RunOpts{Dir: dir, AllowError: true})
+	require.NoError(t, err, "running vendir sync")
+}
+
+func syncMergeDiffOnly(t *testing.T, vendir Vendir, dir string) {
+	t.Helper()
+	_, err := vendir.RunWithOpts([]string{"sync", "--merge-diff-only"},
+		RunOpts{Dir: dir, AllowError: true})
+	require.NoError(t, err, "running vendir sync --merge-diff-only")
+}
+
+// modTimes maps the given paths, relative to dir, to their modification time
+func modTimes(t *testing.T, dir string, paths ...string) map[string]time.Time {
+	t.Helper()
+
+	times := map[string]time.Time{}
+	for _, path := range paths {
+		stat, err := os.Stat(filepath.Join(dir, path))
+		require.NoError(t, err, "getting stats for %s", path)
+		times[path] = stat.ModTime()
+	}
+
+	return times
+}
+
+func assertFileContents(t *testing.T, dir, path, expected string) {
+	t.Helper()
+
+	bytes, err := os.ReadFile(filepath.Join(dir, path))
+	require.NoError(t, err, "reading %s", path)
+	assert.Equal(t, expected, string(bytes), "contents of %s", path)
+}


### PR DESCRIPTION
vendir sync replaced the whole final location on every run: it deleted the directory and renamed the staging directory over it. 
Every file came back with a fresh mtime and inode even when nothing had changed, which wakes up file watchers, build caches and IDEs for no reason.

Reconcile the staging directory against the final location instead. Regular files whose size and sha256 match, and symlinks pointing at the same target, are left alone; only changed and new entries are moved over, stale ones are deleted, and permissions are aligned with a chmod, which does not touch mtimes.

Manually managed contents are no longer staged at all. They used to be renamed out to the staging directory and back, which left their parent directory looking modified. The reconcile is told to preserve them instead, so vendir does not touch them at all.