### PR TITLE
Report a malformed github release slug instead of panicking

### DIFF
--- a/pkg/vendir/fetch/githubrelease/sync.go
+++ b/pkg/vendir/fetch/githubrelease/sync.go
@@ -237,8 +237,10 @@ func (d Sync) matchesAssetName(name string) (bool, error) {
 func (d Sync) fetchTagSelection() (string, error) {
 	listOpt := github.ListOptions{PerPage: 40}
 	tags := []string{}
-	ownerName := strings.Split(d.opts.Slug, "/")[0]
-	repoName := strings.Split(d.opts.Slug, "/")[1]
+	ownerName, repoName, found := strings.Cut(d.opts.Slug, "/")
+	if !found || ownerName == "" || repoName == "" {
+		return "", fmt.Errorf("Expected github release slug to be in 'organization/repository' format, but was '%s'", d.opts.Slug)
+	}
 
 	for {
 		tagList, resp, err := d.client.Repositories.ListTags(context.Background(), ownerName, repoName, &listOpt)

--- a/pkg/vendir/fetch/githubrelease/sync_slug_test.go
+++ b/pkg/vendir/fetch/githubrelease/sync_slug_test.go
@@ -1,0 +1,28 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package githubrelease
+
+import (
+	"strings"
+	"testing"
+
+	ctlconf "carvel.dev/vendir/pkg/vendir/config"
+)
+
+// A slug is taken from vendir.yml as written, and nothing validates its shape
+// before it is split, so a missing organization used to be an index panic.
+func TestFetchTagSelectionRejectsMalformedSlug(t *testing.T) {
+	for _, slug := range []string{"norepo", "", "/repo", "owner/"} {
+		d := Sync{opts: ctlconf.DirectoryContentsGithubRelease{Slug: slug}}
+
+		_, err := d.fetchTagSelection()
+		if err == nil {
+			t.Errorf("slug %q: expected an error, got none", slug)
+			continue
+		}
+		if !strings.Contains(err.Error(), "organization/repository") {
+			t.Errorf("slug %q: expected a format error, got %v", slug, err)
+		}
+	}
+}


### PR DESCRIPTION
`fetchTagSelection` splits `opts.Slug` on `/` and indexes element 1 without checking the result:

```go
ownerName := strings.Split(d.opts.Slug, "/")[0]
repoName := strings.Split(d.opts.Slug, "/")[1]
```

Nothing between `vendir.yml` and that line checks the slug's shape. `DirectoryContentsGithubRelease.Slug` is a plain string with an `// e.g. organization/repository` comment, and I could not find a format check anywhere in the tree. So a config that omits the organization crashes the sync:

```yaml
githubRelease:
  slug: myrepo
  tagSelection:
    semver: {constraints: ">=1.0.0"}
```

```
panic: runtime error: index out of range [1] with length 1
```

The split runs before the first API call, so it happens with no network access and no token configured.

`strings.Cut` now covers it, and empty owner or repo halves (`/repo`, `owner/`) are rejected too. The message names the expected format so the fix is obvious from the output.

The test drives `fetchTagSelection` directly for all four malformed shapes, which needs no client. It panics without the change.
