### PR TITLE
fix: feature requests can't go stale

### DIFF
--- a/.github/workflows/stale-issues-action.yml
+++ b/.github/workflows/stale-issues-action.yml
@@ -15,7 +15,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is being marked as stale due to a long period of inactivity and will be closed in 5 days if there is no response.'
         stale-issue-label: 'stale'
-        exempt-issue-labels: 'discussion'
+        exempt-issue-labels: 'discussion,enhancement'
         only-labels: 'carvel-triage'
         days-before-stale: 40
         days-before-close: 5


### PR DESCRIPTION
I'd much prefer the stale bot just be removed entirely (https://drewdevault.com/blog/stalebot/), but I figured I'd start small :P