### PR TITLE
Read a secret's stringData as well as its data

### DIFF
--- a/pkg/vendir/config/config.go
+++ b/pkg/vendir/config/config.go
@@ -49,6 +49,7 @@ func NewConfigFromFiles(paths []string) (Config, []Secret, []ConfigMap, error) {
 			if err != nil {
 				return fmt.Errorf("Unmarshaling secret: %s", err)
 			}
+			secret.FoldStringData()
 
 			if s, ok := secretsNames[secret.Metadata.Name]; ok {
 				if !reflect.DeepEqual(s.Data, secret.Data) {

--- a/pkg/vendir/config/config_test.go
+++ b/pkg/vendir/config/config_test.go
@@ -327,3 +327,84 @@ metadata:
 		assert.Contains(t, err.Error(), "Expected to find one secret 'ssh-key-secret', but found multiple")
 	})
 }
+
+func TestSecretStringData(t *testing.T) {
+	writeConfig := func(t *testing.T, secret string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "config.yml")
+		contents := secret + `
+---
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+- path: charts
+  contents:
+  - path: myChart
+    helmChart:
+      name: mychart
+      version: "1.1.1"
+      repository:
+        url: https://registry.example.com/charts/
+        secretRef:
+          name: auth
+`
+		require.NoError(t, os.WriteFile(path, []byte(contents), 0666))
+		return path
+	}
+
+	t.Run("stringData is read", func(t *testing.T) {
+		path := writeConfig(t, `apiVersion: v1
+kind: Secret
+metadata:
+  name: auth
+stringData:
+  username: admin
+  password: hunter2`)
+
+		_, secrets, _, err := config.NewConfigFromFiles([]string{path})
+		require.NoError(t, err)
+		require.Len(t, secrets, 1)
+		assert.Equal(t, map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("hunter2"),
+		}, secrets[0].Data)
+	})
+
+	t.Run("data is still read", func(t *testing.T) {
+		path := writeConfig(t, `apiVersion: v1
+kind: Secret
+metadata:
+  name: auth
+data:
+  username: YWRtaW4=
+  password: aHVudGVyMg==`)
+
+		_, secrets, _, err := config.NewConfigFromFiles([]string{path})
+		require.NoError(t, err)
+		require.Len(t, secrets, 1)
+		assert.Equal(t, map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("hunter2"),
+		}, secrets[0].Data)
+	})
+
+	t.Run("stringData wins over data for the same key", func(t *testing.T) {
+		path := writeConfig(t, `apiVersion: v1
+kind: Secret
+metadata:
+  name: auth
+data:
+  username: YWRtaW4=
+  password: ZnJvbS1kYXRh
+stringData:
+  password: from-string-data`)
+
+		_, secrets, _, err := config.NewConfigFromFiles([]string{path})
+		require.NoError(t, err)
+		require.Len(t, secrets, 1)
+		assert.Equal(t, map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("from-string-data"),
+		}, secrets[0].Data)
+	})
+}

--- a/pkg/vendir/config/data.go
+++ b/pkg/vendir/config/data.go
@@ -31,6 +31,26 @@ type Secret struct {
 	Metadata GenericMetadata
 	Type     string
 	Data     map[string][]byte
+	// StringData holds the same values as Data, unencoded. Kubernetes accepts
+	// either, so a secret written by hand usually uses this one.
+	StringData map[string]string
+}
+
+// FoldStringData moves any StringData entries into Data, so that everything
+// reading a secret only has to look in one place. Kubernetes gives StringData
+// precedence when a key appears in both, so do the same.
+func (s *Secret) FoldStringData() {
+	if len(s.StringData) == 0 {
+		return
+	}
+
+	if s.Data == nil {
+		s.Data = map[string][]byte{}
+	}
+	for k, v := range s.StringData {
+		s.Data[k] = []byte(v)
+	}
+	s.StringData = nil
 }
 
 //nolint:revive


### PR DESCRIPTION
Fixes #460.

`config.Secret` only declares `Data map[string][]byte`, so `stringData` has nothing to unmarshal into and is dropped on the floor. Every reader then does `secret.Data[ctlconf.SecretK8sCorev1BasicAuthUsernameKey]`, gets the zero value and carries on without credentials, which is why this shows up as a 401 from the registry instead of as a problem with the config.

`stringData` is the form you get when a secret is written by hand rather than generated, since the values are not base64, so it is likely the common shape for people hitting this.

This adds `StringData` to the struct and folds it into `Data` right after the unmarshal in `NewConfigFromFiles`, so nothing downstream has to know about it. On a key present in both, `stringData` wins, matching Kubernetes.

Three subtests through `NewConfigFromFiles` using the `helmChart.repository.secretRef` config from the issue: `stringData` alone, `data` alone, and both with an overlapping key. Against `develop`:

```
--- FAIL: TestSecretStringData/stringData_is_read
--- PASS: TestSecretStringData/data_is_still_read
--- FAIL: TestSecretStringData/stringData_wins_over_data_for_the_same_key
```

The middle one passing either way is the point of including it, since the change touches the path that already worked.

`go build ./...`, `go vet ./pkg/vendir/config/` and `go test ./pkg/...` are clean. I did not run `./test/e2e`, it wants a `helm3` binary and a local registry that I do not have here.
